### PR TITLE
Add theme selector with persistent color themes

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,7 +34,12 @@
                 <li><a href="#testimonials">Testimonials</a></li>
                 <li><a href="#contact">Contact</a></li>
             </ul>
-                <button id="darkModeToggle" class="btn btn-secondary">Toggle Theme</button>
+            <button id="darkModeToggle" class="btn btn-secondary">Toggle Theme</button>
+            <select id="themeSelector" class="theme-selector" aria-label="Color theme">
+                <option value="blue">Blue</option>
+                <option value="green">Green</option>
+                <option value="orange">Orange</option>
+            </select>
         </nav>
     </header>
 

--- a/script.js
+++ b/script.js
@@ -31,6 +31,23 @@ if (typedHero) {
     });
 }
 
+// Theme selector
+function applyTheme(theme) {
+    document.body.classList.remove('theme-blue', 'theme-green', 'theme-orange');
+    document.body.classList.add(`theme-${theme}`);
+}
+const themeSelector = document.getElementById('themeSelector');
+if (themeSelector) {
+    const savedTheme = localStorage.getItem('color-theme') || 'blue';
+    applyTheme(savedTheme);
+    themeSelector.value = savedTheme;
+    themeSelector.addEventListener('change', () => {
+        const theme = themeSelector.value;
+        applyTheme(theme);
+        localStorage.setItem('color-theme', theme);
+    });
+}
+
 const counterElements = document.querySelectorAll('.stat-number');
 counterElements.forEach(element => {
     const targetCount = parseInt(element.dataset.count);

--- a/style.css
+++ b/style.css
@@ -16,6 +16,20 @@ html {
     --text-light-color: #e0e0e0;
 }
 
+/* Theme color sets */
+.theme-blue {
+    --primary-color: #007bff;
+    --secondary-color: #6c757d;
+}
+.theme-green {
+    --primary-color: #28a745;
+    --secondary-color: #218838;
+}
+.theme-orange {
+    --primary-color: #fd7e14;
+    --secondary-color: #e8590c;
+}
+
 body {
     font-family: 'Nunito Sans', sans-serif;
     line-height: 1.8;
@@ -786,6 +800,12 @@ body.dark-mode #scrollProgress {
 }
 #darkModeToggle {
     margin-left: auto;
+}
+#themeSelector {
+    margin-left: 15px;
+    padding: 8px 12px;
+    border-radius: 6px;
+    border: 1px solid var(--secondary-color);
 }
 #backToTop {
     position: fixed;


### PR DESCRIPTION
## Summary
- introduce color theme classes for blue, green and orange
- add dropdown to choose theme
- persist color theme in localStorage and apply on load

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_683fbd403568832eb9edd3d9659c9fd0