### PR TITLE
Add offline page and service worker support

### DIFF
--- a/offline.html
+++ b/offline.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Offline - ApexBuild</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <header class="header">
+        <nav class="navbar container">
+            <a href="index.html" class="logo">ApexBuild</a>
+        </nav>
+    </header>
+
+    <main class="container">
+        <h1>You're Offline</h1>
+        <p>It seems you have lost your internet connection. Please check your network and try again.</p>
+        <a href="index.html">Reload</a>
+    </main>
+</body>
+</html>

--- a/sw.js
+++ b/sw.js
@@ -1,9 +1,10 @@
-const cacheName = 'apex-cache-v3';
+const cacheName = 'apex-cache-v4';
 const assets = [
   'index.html',
   'style.css',
   'script.js',
   '404.html',
+  'offline.html',
   'privacy.html',
   'terms.html',
   'manifest.json',
@@ -30,7 +31,7 @@ self.addEventListener('fetch', event => {
   const { request } = event;
   if (request.mode === 'navigate') {
     event.respondWith(
-      fetch(request).catch(() => caches.match('index.html'))
+      fetch(request).catch(() => caches.match('offline.html'))
     );
     return;
   }


### PR DESCRIPTION
## Summary
- add `offline.html` with simple connectivity message
- update `sw.js` to precache `offline.html` and serve it when navigation fetches fail

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/WebsiteTest/package.json')*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_683fd406408c832e81b2c3610a4b410d