### PR TITLE
Refactor navigation to use popovers

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,16 +52,18 @@
     <header class="header">
         <nav class="navbar container" role="navigation" aria-label="Main navigation">
             <a href="#" class="logo" aria-label="Homepage">ApexBuild</a>
-            <button id="mobileMenuToggle" class="hamburger" aria-label="Toggle navigation" aria-expanded="false"><i class="fas fa-bars"></i></button>
-            <ul id="navMenu" class="nav-links">
-                <li><a href="#about">About Us</a></li>
-                <li><a href="#services">Services</a></li>
-                <li><a href="#projects">Projects</a></li>
-                <li><a href="#testimonials">Testimonials</a></li>
-                <li><a href="#contact">Contact</a></li>
-            </ul>
-                <button id="darkModeToggle" class="btn btn-secondary" aria-pressed="false" aria-describedby="themeTip">Toggle Theme</button>
-                <div id="themeTip" class="tooltip" role="tooltip">Toggle light/dark</div>
+            <button popovertarget="navMenu" aria-controls="navMenu" class="hamburger" aria-label="Toggle navigation"><i class="fas fa-bars"></i></button>
+            <nav id="navMenu" popover>
+                <ul class="nav-links">
+                    <li><a href="#about">About Us</a></li>
+                    <li><a href="#services">Services</a></li>
+                    <li><a href="#projects">Projects</a></li>
+                    <li><a href="#testimonials">Testimonials</a></li>
+                    <li><a href="#contact">Contact</a></li>
+                </ul>
+            </nav>
+            <button id="darkModeToggle" class="btn btn-secondary" aria-pressed="false" aria-describedby="themeTip">Toggle Theme</button>
+            <div id="themeTip" class="tooltip" role="tooltip">Toggle light/dark</div>
         </nav>
     </header>
 <main id="mainContent">

--- a/script.js
+++ b/script.js
@@ -139,16 +139,7 @@ if (darkToggle) {
         localStorage.setItem('dark-mode', active);
         darkToggle.setAttribute('aria-pressed', active ? 'true' : 'false');
     });
-    if (themeTip) {
-        function positionTip() {
-            const rect = darkToggle.getBoundingClientRect();
-            themeTip.style.left = rect.left + rect.width / 2 + 'px';
-            themeTip.style.top = rect.bottom + window.scrollY + 'px';
-        }
-        positionTip();
-        window.addEventListener('resize', positionTip);
-        window.addEventListener('scroll', positionTip);
-    }
+    // Tooltip visibility handled via CSS
 }
 
 // Sticky header & back to top button
@@ -181,14 +172,19 @@ if (backToTop) {
 }
 
 // Mobile navigation
-const menuToggle = document.getElementById('mobileMenuToggle');
+const menuToggle = document.querySelector('[popovertarget="navMenu"]');
 const navMenu = document.getElementById('navMenu');
-if (menuToggle && navMenu) {
-    menuToggle.addEventListener('click', () => {
-        navMenu.classList.toggle('open');
-        const expanded = navMenu.classList.contains('open');
-        menuToggle.setAttribute('aria-expanded', expanded);
-    });
+if (menuToggle && navMenu && navMenu.showPopover) {
+    const mq = window.matchMedia('(min-width: 768px)');
+    function updateNav() {
+        if (mq.matches) {
+            navMenu.showPopover();
+        } else {
+            navMenu.hidePopover();
+        }
+    }
+    updateNav();
+    mq.addEventListener('change', updateNav);
 }
 
 // Highlight active nav link on scroll

--- a/style.css
+++ b/style.css
@@ -751,9 +751,8 @@ img {
         text-align: center;
         margin-top: 15px;
         gap: 15px;
-        display: none;
     }
-    #navMenu.open {
+    #navMenu:popover-open {
         display: flex;
     }
     #navMenu li a {
@@ -835,6 +834,7 @@ body.dark-mode #scrollProgress {
 }
 #darkModeToggle {
     margin-left: auto;
+    position: relative;
 }
 #backToTop {
     position: fixed;
@@ -924,10 +924,12 @@ body.dark-mode #scrollProgress {
     z-index: 1200;
 }
 
-/* Tooltip positioned via JavaScript */
+/* Tooltip anchored to toggle button */
 .tooltip {
     position: absolute;
-    transform: translate(-50%, 8px);
+    top: 100%;
+    left: 50%;
+    transform: translateX(-50%);
     background: var(--accent-color);
     color: #fff;
     padding: 6px 10px;
@@ -935,4 +937,8 @@ body.dark-mode #scrollProgress {
     font-size: 0.9rem;
     white-space: nowrap;
     z-index: 1200;
+    display: none;
+}
+#darkModeToggle:focus + #themeTip {
+    display: block;
 }


### PR DESCRIPTION
## Summary
- switch mobile menu to `<nav popover>` with a `<button popovertarget>` trigger
- drop JS tooltip positioning and manage via CSS
- auto-show nav popover on large screens

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_683fd41100a0832e8bf7311c7f12c2c1