### PR TITLE
Add hero text cycling

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ persists on subsequent visits. Available variants correspond to the
 
 Edit these portions to customize animations or disable features as needed.
 
+The hero tagline rotates through a set of phrases defined in `script.js`. Update
+the `phrases` array to change the words that cycle below the main heading.
+
 ## Development Tips
 
 - Ensure you have an internet connection so the CDN links for fonts and third-party libraries load correctly.

--- a/index.html
+++ b/index.html
@@ -72,6 +72,7 @@
         <canvas id="particleCanvas" aria-hidden="true"></canvas>
         <div class="hero-content container">
             <h1>Construct the future with confidence</h1>
+            <span id="heroTyped"></span>
             <a href="#projects" class="btn">Explore Our Portfolio</a>
         </div>
         <div class="hero-wave"></div>

--- a/script.js
+++ b/script.js
@@ -50,6 +50,40 @@ if (prefersReducedMotion) {
     document.documentElement.classList.add('reduce-motion');
 }
 
+// Cycle hero tagline text
+const heroTyped = document.getElementById('heroTyped');
+if (heroTyped) {
+    const phrases = [
+        'Innovative Designs',
+        'Quality Craftsmanship',
+        'Timely Delivery'
+    ];
+    let pIndex = 0;
+    let cIndex = 0;
+    let deleting = false;
+
+    const type = () => {
+        const text = phrases[pIndex];
+        if (deleting) {
+            heroTyped.textContent = text.slice(0, cIndex--);
+            if (cIndex < 0) {
+                deleting = false;
+                pIndex = (pIndex + 1) % phrases.length;
+            }
+        } else {
+            heroTyped.textContent = text.slice(0, cIndex++);
+            if (cIndex > text.length) {
+                deleting = true;
+                cIndex = text.length;
+                setTimeout(type, 1500);
+                return;
+            }
+        }
+        setTimeout(type, 120);
+    };
+    if (!prefersReducedMotion) type();
+}
+
 // Simple particle line effect in hero canvas
 const canvas = document.getElementById('particleCanvas');
 if (canvas && canvas.getContext) {


### PR DESCRIPTION
## Summary
- add typed text placeholder under hero heading
- rotate hero tagline phrases via script
- document customizing the phrase list in README

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683fd9694910832ead9c6e3600ab6856