### PR TITLE
Update service worker installation and prompt user

### DIFF
--- a/script.js
+++ b/script.js
@@ -336,5 +336,24 @@ if ('PerformanceObserver' in window) {
 
 // Register service worker
 if ('serviceWorker' in navigator) {
-    navigator.serviceWorker.register('sw.js');
+    navigator.serviceWorker.register('sw.js').then(reg => {
+        function promptRefresh() {
+            if (confirm('A new version is available. Reload now?')) {
+                window.location.reload();
+            }
+        }
+        if (reg.waiting) {
+            promptRefresh();
+        }
+        reg.addEventListener('updatefound', () => {
+            const newWorker = reg.installing;
+            if (newWorker) {
+                newWorker.addEventListener('statechange', () => {
+                    if (newWorker.state === 'installed' && reg.waiting) {
+                        promptRefresh();
+                    }
+                });
+            }
+        });
+    });
 }

--- a/sw.js
+++ b/sw.js
@@ -15,7 +15,10 @@ const assets = [
 
 self.addEventListener('install', event => {
   event.waitUntil(
-    caches.open(cacheName).then(cache => cache.addAll(assets))
+    caches
+      .open(cacheName)
+      .then(cache => cache.addAll(assets))
+      .then(() => self.skipWaiting())
   );
 });
 


### PR DESCRIPTION
## Summary
- activate new service worker immediately using `skipWaiting`
- prompt visitors when new service worker is ready so they can refresh

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683fd980abe8832e9f58719389c177c5