### PR TITLE
Enable subgrid and container queries

### DIFF
--- a/style.css
+++ b/style.css
@@ -261,17 +261,31 @@ img {
 }
 
 /* About Section */
-.about-content {
+.about {
+    container-type: inline-size;
     display: grid;
-    grid-template-columns: 1fr 1fr;
+    grid-template-columns: 1fr;
     gap: 80px;
     align-items: center;
+}
+
+@container (min-width: 700px) {
+    .about {
+        grid-template-columns: 1fr 1fr;
+    }
+}
+
+.about-content {
+    display: grid;
+    grid-template-columns: subgrid;
+    grid-template-rows: subgrid;
 }
 .about-image {
     border-radius: 15px;
     overflow: hidden;
     box-shadow: 0 12px 30px rgba(0,0,0,0.15);
     transition: box-shadow 0.4s ease;
+    margin-bottom: 60px;
 }
 .about-image:hover {
     box-shadow: 0 15px 35px rgba(0,0,0,0.2);
@@ -281,6 +295,12 @@ img {
 }
 .about-image:hover img {
     transform: scale(1.06);
+}
+
+@container (min-width: 700px) {
+    .about-image {
+        margin-bottom: 0;
+    }
 }
 .about-text h2 {
     font-size: 2.8rem;
@@ -321,22 +341,24 @@ img {
     background-color: #f0f0f0;
     padding-bottom: 120px;
     container-type: inline-size;
+    display: grid;
+    grid-template-columns: 1fr;
 }
 .services-grid {
     display: grid;
-    grid-template-columns: 1fr;
-    grid-template-rows: auto auto 1fr;
+    grid-template-columns: subgrid;
+    grid-template-rows: subgrid;
     gap: 50px;
 }
 
 @container (min-width: 600px) {
-    .services-grid {
+    .services {
         grid-template-columns: repeat(2, 1fr);
     }
 }
 
 @container (min-width: 900px) {
-    .services-grid {
+    .services {
         grid-template-columns: repeat(3, 1fr);
     }
 }
@@ -389,6 +411,7 @@ img {
 /* Projects Section */
 .projects {
     padding-bottom: 120px;
+    container-type: inline-size;
 }
 .case-carousel {
     width: 100%;
@@ -492,6 +515,31 @@ img {
 .carousel-prev { left: 20px; }
 .carousel-next { right: 20px; }
 
+@container (min-width: 600px) {
+    .case-carousel {
+        display: grid;
+        grid-template-columns: repeat(2, 1fr);
+        gap: 40px;
+        position: static;
+    }
+    .case-slide {
+        position: static;
+        opacity: 1;
+        pointer-events: auto;
+    }
+    .carousel-prev,
+    .carousel-next,
+    .carousel-dots {
+        display: none;
+    }
+}
+
+@container (min-width: 900px) {
+    .case-carousel {
+        grid-template-columns: repeat(3, 1fr);
+    }
+}
+
 /* Testimonials Section */
 .testimonials {
     background-color: #eef0f2;
@@ -585,15 +633,23 @@ img {
 .contact {
     background-color: #fff;
     padding-bottom: 140px;
+    container-type: inline-size;
 }
 .contact-content {
     display: grid;
-    grid-template-columns: 1fr 1fr;
+    grid-template-columns: 1fr;
     gap: 70px;
     align-items: center;
 }
+
+@container (min-width: 600px) {
+    .contact-content {
+        grid-template-columns: 1fr 1fr;
+    }
+}
 .contact-info {
     padding: 50px;
+    margin-bottom: 60px;
 }
 .contact-info h3 {
     font-size: 2.2rem;
@@ -606,6 +662,12 @@ img {
     color: #666;
     font-weight: 400;
     line-height: 1.9;
+}
+
+@container (min-width: 600px) {
+    .contact-info {
+        margin-bottom: 0;
+    }
 }
 .contact-details-list {
     list-style: none;
@@ -762,13 +824,6 @@ img {
     }
     .hero p {
         font-size: 1.4rem;
-    }
-    .about-content, .contact-content {
-        grid-template-columns: 1fr;
-        text-align: center;
-    }
-    .about-image, .contact-info {
-        margin-bottom: 60px;
     }
     /* .services-grid layout handled with container queries */
 }


### PR DESCRIPTION
## Summary
- align about and services sections using CSS subgrid
- add container queries to projects and contact sections
- keep layouts readable on small screens

## Testing
- `npm run build` *(fails: minify not found)*
- `npm test` *(fails: html-validate not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fe1c8a9b4832e918fa23d74b35174