### PR TITLE
Add basic offline caching

### DIFF
--- a/offline.html
+++ b/offline.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Offline</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <main class="offline" style="text-align:center;padding:4rem 1rem;">
+    <h1>Offline</h1>
+    <p>You are currently offline. Please check your internet connection.</p>
+    <a href="/" class="cta">Try Again</a>
+  </main>
+</body>
+</html>

--- a/sw.js
+++ b/sw.js
@@ -1,7 +1,30 @@
-self.addEventListener('install', e => {
+const CACHE = 'site-v1';
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE).then(cache => {
+      return cache.addAll([
+        '/index.html',
+        '/offline.html',
+        '/styles.css',
+        '/scripts.js',
+        'https://placehold.co/96x96',
+        'https://placehold.co/180x180',
+        'https://placehold.co/1920x1080',
+        'https://placehold.co/800x600',
+        'https://placehold.co/400',
+        'https://placehold.co/1200x630'
+      ]);
+    })
+  );
   self.skipWaiting();
 });
-self.addEventListener('fetch', e => {
-  // simple passthrough
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request).then(response => {
+      return response || fetch(event.request).catch(() => caches.match('offline.html'));
+    })
+  );
 });
 


### PR DESCRIPTION
## Summary
- add an offline fallback page
- cache essential assets and remote images in `sw.js`
- handle fetch events with offline fallback

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840d43ab568832e9ce31655ccb9b2ff