### PR TITLE
Persist user theme preference

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -9,8 +9,16 @@ navToggle.addEventListener('click', () => {
 
 // Dark mode toggle
 const modeToggle = document.querySelector('.mode-toggle');
+
+// Apply saved preference on load
+const savedTheme = localStorage.getItem('theme');
+if (savedTheme === 'dark') {
+  document.documentElement.classList.add('dark-mode');
+}
+
 modeToggle.addEventListener('click', () => {
-  document.documentElement.classList.toggle('dark-mode');
+  const isDark = document.documentElement.classList.toggle('dark-mode');
+  localStorage.setItem('theme', isDark ? 'dark' : 'light');
 });
 
 // Intersection animations

--- a/styles.css
+++ b/styles.css
@@ -76,6 +76,8 @@ a:hover {text-decoration: underline;}
 
 .dark-mode{--color-bg:var(--color-dark-bg);--color-text:var(--color-dark-text);}
 
+.dark-mode .card {background:#333; color:var(--color-dark-text);}
+
 .card,.about,.testimonial-grid figure,.contact form{opacity:0;transform:translateY(20px);transition:opacity var(--transition-fast),transform var(--transition-fast);}
 .show{opacity:1;transform:none;}
 


### PR DESCRIPTION
## Summary
- remember selected theme in localStorage
- read theme preference on load
- tweak card styling in dark mode

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840d43c78c0832e8b1b58f033c6d9ec