### PR TITLE
Add social media icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -118,8 +118,18 @@
 </main>
 <footer class="footer">
   <div class="social">
-    <a href="#" aria-label="Twitter">T</a>
-    <a href="#" aria-label="LinkedIn">L</a>
+    <a href="#" aria-label="Twitter">
+      <svg aria-hidden="true" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M23 3a10.9 10.9 0 01-3.14 1.53A4.48 4.48 0 0016 3a4.48 4.48 0 00-4.39 5.48A12.94 12.94 0 013 4s-4 9 5 13a13.06 13.06 0 01-8 2c9 5 20 0 20-11.5a4.5 4.5 0 00-.08-.83A7.72 7.72 0 0023 3z"/>
+      </svg>
+    </a>
+    <a href="#" aria-label="LinkedIn">
+      <svg aria-hidden="true" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M16 8a6 6 0 016 6v7h-4v-7a2 2 0 00-4 0v7h-4V9h4v3a4 4 0 014-4z"/>
+        <rect x="2" y="9" width="4" height="12"/>
+        <circle cx="4" cy="4" r="2"/>
+      </svg>
+    </a>
   </div>
   <p>&copy; <span id="year"></span> Acme Corp. All rights reserved.</p>
 </footer>

--- a/styles.css
+++ b/styles.css
@@ -91,6 +91,7 @@ a:hover {text-decoration: underline;}
 .contact button:hover {background:#128066;}
 .footer {text-align:center; padding:2rem 1rem; background:#222; color:#fff;}
 .footer a {color:#fff; margin:0 0.5rem;}
+.footer svg {width:1.5rem; height:1.5rem; vertical-align:middle;}
 .mode-toggle {position:fixed; bottom:1rem; right:1rem; background:var(--color-accent); border:none; color:#fff; padding:0.5rem; border-radius:50%; font-size:1.2rem; cursor:pointer;}
 
 .scroll-top{position:fixed;bottom:4rem;right:1rem;background:var(--color-accent);border:none;color:#fff;padding:0.5rem;border-radius:50%;font-size:1.2rem;cursor:pointer;display:none;}


### PR DESCRIPTION
## Summary
- show Twitter and LinkedIn icons inline instead of placeholder letters
- size social icons consistently in footer

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6840da7c9bf4832e868055890090dd14