### PR TITLE
Add Google font to styles

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1,6 +1,8 @@
+@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;700&display=swap');
+
 /* Variables */
 :root {
-  --font-family: 'DejaVu Sans', system-ui, sans-serif;
+  --font-family: 'Poppins', 'DejaVu Sans', system-ui, sans-serif;
   --color-bg: #f5f5f5;
   --color-text: #333;
   --color-accent: #16a085;


### PR DESCRIPTION
## Summary
- import **Poppins** from Google Fonts
- set `--font-family` to use Poppins before the existing fallbacks

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/WebsiteTest/package.json')*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6840da799cfc832e928f2ee8ea487633