### PR TITLE
Improve hero text contrast with overlay

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -69,7 +69,19 @@ a:hover {text-decoration: underline;}
   align-items:center;
   text-align:center;
   color:#fff;
+  position:relative;
 }
+
+.hero::before {
+  content:"";
+  position:absolute;
+  inset:0;
+  background:linear-gradient(rgba(0,0,0,0.4), rgba(0,0,0,0.6));
+  z-index:0;
+  pointer-events:none;
+}
+
+.hero-content{position:relative;z-index:1;}
 .hero .cta {background: var(--color-accent); color:white; padding:0.75rem 1.5rem; border-radius:4px; display:inline-block; margin-top:1rem; transition:background var(--transition-fast);} 
 .hero .cta:hover {background:#128066;}
 .features {padding:4rem 1rem;}


### PR DESCRIPTION
## Summary
- add pseudo-element overlay to the hero section
- ensure hero content sits above the overlay

## Testing
- `python3 -m http.server 8000` *(server started without errors)*

------
https://chatgpt.com/codex/tasks/task_e_6840da75a104832eb8c8e40aecdedc73