### PR TITLE
Add missing PWA icon sizes

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ npx http-server -p 8000
 
 ## PWA features
 
-- **Web App Manifest** (`manifest.json`) defines the name, icons, start URL and theme color so the site can be installed on a home screen.
+- **Web App Manifest** (`manifest.json`) defines the name, start URL and theme color, and includes icons at `96x96`, `192x192` and `512x512` so the site can be installed on a home screen.
 - **Service Worker** (`sw.js`) is registered in `scripts.js` to enable basic offline support.
 - **Theme color** meta tag customizes the browser UI when the site is installed or opened on mobile.
 

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,20 @@
   "background_color": "#34495e",
   "theme_color": "#34495e",
   "icons": [
-    {"src": "https://placehold.co/96x96", "sizes": "96x96", "type": "image/png"}
+    {
+      "src": "https://placehold.co/96x96",
+      "sizes": "96x96",
+      "type": "image/png"
+    },
+    {
+      "src": "https://placehold.co/192x192",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "https://placehold.co/512x512",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
   ]
 }
-


### PR DESCRIPTION
## Summary
- add 192x192 and 512x512 icons to `manifest.json`
- mention the new icon sizes in the README

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840da725a8c832eaed2ec123c374f0e