### PR TITLE
Add service worker caching for offline support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ npx http-server -p 8000
 ## PWA features
 
 - **Web App Manifest** (`manifest.json`) defines the name, icons, start URL and theme color so the site can be installed on a home screen.
-- **Service Worker** (`sw.js`) is registered in `scripts.js` to enable basic offline support.
+- **Service Worker** (`sw.js`) caches core assets and serves `offline.html` when network requests fail.
 - **Theme color** meta tag customizes the browser UI when the site is installed or opened on mobile.
 
 These features illustrate how to turn a regular static page into a lightweight PWA.

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,41 @@
+const CACHE_NAME = 'site-cache-v1';
+const OFFLINE_URL = 'offline.html';
+
+const CORE_ASSETS = [
+  '/',
+  'index.html',
+  OFFLINE_URL,
+  'styles.css',
+  'scripts.js',
+  '404.html',
+  'manifest.json',
+  'robots.txt',
+  'sitemap.xml'
+];
+
+self.addEventListener('install', event => {
+  self.skipWaiting();
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(CORE_ASSETS))
+  );
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(keys => Promise.all(
+      keys.filter(key => key !== CACHE_NAME).map(key => caches.delete(key))
+    ))
+  );
+});
+
+self.addEventListener('fetch', event => {
+  if (event.request.mode === 'navigate') {
+    event.respondWith(
+      fetch(event.request).catch(() => caches.match(OFFLINE_URL))
+    );
+    return;
+  }
+  event.respondWith(
+    caches.match(event.request).then(res => res || fetch(event.request))
+  );
+});


### PR DESCRIPTION
## Summary
- implement service worker that caches core assets and returns `offline.html` if network is unavailable
- document the new offline behaviour in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840da69424c832ea4a4a37414e463b9