### PR TITLE
Remove inline styles from error pages

### DIFF
--- a/404.html
+++ b/404.html
@@ -8,7 +8,7 @@
 </head>
 <body>
   <a href="#main" class="skip-link">Skip to main content</a>
-  <main id="main" class="not-found" style="text-align:center;padding:4rem 1rem;">
+  <main id="main" class="not-found">
     <h1>404</h1>
     <p>The page you are looking for doesn't exist.</p>
     <a href="/" class="cta">Go Home</a>

--- a/offline.html
+++ b/offline.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="styles.css">
 </head>
 <body>
-  <main class="offline" style="text-align:center;padding:4rem 1rem;">
+  <main class="offline">
     <h1>Offline</h1>
     <p>You are currently offline. Please check your internet connection.</p>
     <a href="/" class="cta">Try Again</a>

--- a/styles.css
+++ b/styles.css
@@ -103,3 +103,10 @@ a:hover {text-decoration: underline;}
 .card,.about,.testimonial-grid figure,.contact form{opacity:0;transform:translateY(20px);transition:opacity var(--transition-fast),transform var(--transition-fast);}
 .show{opacity:1;transform:none;}
 
+/* Styles for standalone pages */
+.offline,
+.not-found {
+  text-align: center;
+  padding: 4rem 1rem;
+}
+


### PR DESCRIPTION
## Summary
- remove inline styles from `offline.html` and `404.html`
- add dedicated `.offline` and `.not-found` rules to stylesheet

## Testing
- `python3 -m http.server 8000` *(served pages locally)*
- `curl -s http://localhost:8000/offline.html | head -n 5`
- `curl -s http://localhost:8000/404.html | head -n 5`


------
https://chatgpt.com/codex/tasks/task_e_6840da59d1a8832e999a87c9f74745ae