### PR TITLE
Add aria-hidden attribute handling for navigation menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
 <header class="hero" id="top">
   <nav class="nav" aria-label="Main Navigation">
     <button class="nav-toggle" aria-label="Toggle navigation" aria-expanded="false">&#9776;</button>
-    <ul class="nav-menu">
+    <ul class="nav-menu" aria-hidden="true">
       <li><a href="#features">Features</a></li>
       <li><a href="#about">About</a></li>
       <li><a href="#testimonials">Testimonials</a></li>

--- a/scripts.js
+++ b/scripts.js
@@ -3,8 +3,10 @@ const navToggle = document.querySelector('.nav-toggle');
 const navMenu = document.querySelector('.nav-menu');
 navToggle.addEventListener('click', () => {
   const expanded = navToggle.getAttribute('aria-expanded') === 'true';
-  navToggle.setAttribute('aria-expanded', !expanded);
+  const newExpanded = !expanded;
+  navToggle.setAttribute('aria-expanded', newExpanded);
   navMenu.classList.toggle('show');
+  navMenu.setAttribute('aria-hidden', !newExpanded);
 });
 
 // Close mobile nav when a link is clicked
@@ -12,6 +14,7 @@ document.querySelectorAll('.nav-menu a').forEach(link => {
   link.addEventListener('click', () => {
     navMenu.classList.remove('show');
     navToggle.setAttribute('aria-expanded', 'false');
+    navMenu.setAttribute('aria-hidden', 'true');
   });
 });
 


### PR DESCRIPTION
## Summary
- hide nav menu from screen readers by default
- update aria-hidden when toggling mobile menu

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6840de13d180832ea280bf69e3121948