### PR TITLE
Add Apple mobile web app meta tags

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,6 +17,8 @@
   <meta name="twitter:description" content="Acme Corp provides elite solutions for tomorrow's market.">
   <meta name="twitter:image" content="https://placehold.co/1200x630">
   <meta name="theme-color" content="#34495e">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="default">
   <meta name="color-scheme" content="light dark">
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' https://placehold.co data:; style-src 'self'; script-src 'self';">
   <link rel="icon" type="image/png" sizes="96x96" href="https://placehold.co/96x96">


### PR DESCRIPTION
## Summary
- enable Apple mobile web app capability
- specify the default iOS status bar style

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6840de0b4e24832e9b9126fd4a575a04