### PR TITLE
Fix hero min-height for mobile

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -69,7 +69,7 @@ a:hover {text-decoration: underline;}
 }
 .hero {
   background: url('https://placehold.co/1920x1080') center/cover no-repeat;
-  min-height: 100vh;
+  min-height: 100dvh;
   display:flex;
   flex-direction:column;
   justify-content:center;


### PR DESCRIPTION
## Summary
- use `100dvh` for hero section to support dynamic viewport height

## Testing
- `grep -R "100vh" -n .`


------
https://chatgpt.com/codex/tasks/task_e_6840ddf5c7a8832e8b0b62aaf5d7ed77