### PR TITLE
Implement focus-visible outlines

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -143,3 +143,13 @@ a:hover {text-decoration: underline;}
   }
 }
 
+/* Focus styles for interactive elements */
+.nav-menu a:focus-visible,
+.cta:focus-visible,
+.nav-toggle:focus-visible,
+.mode-toggle:focus-visible,
+.scroll-top:focus-visible {
+  outline: 3px solid var(--color-text);
+  outline-offset: 2px;
+}
+


### PR DESCRIPTION
## Summary
- ensure keyboard users can see outlines
- add focus-visible styles for nav links, buttons, and toggle controls

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6840dded3f88832ea2621d86a43cc5b1