### PR TITLE
Add customizable hero video with YouTube option

### DIFF
--- a/404.html
+++ b/404.html
@@ -11,6 +11,9 @@
   <a href="#main" class="skip-link">Skip to main content</a>
   <main id="main" class="not-found" style="text-align:center;padding:4rem 1rem;">
     <h1>404</h1>
+    <svg class="rocket" viewBox="0 0 64 64" width="120" height="120" aria-hidden="true">
+      <path d="M32 2l6 14 14 6-14 6-6 14-6-14-14-6 14-6z" fill="none" stroke="currentColor" stroke-width="2"/>
+    </svg>
     <p>The page you are looking for doesn't exist.</p>
     <a href="/" class="cta">Go Home</a>
   </main>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Acme Corp Landing Page
 
-This repository contains a simple static website demonstrating a basic Progressive Web App (PWA) setup for a fictional business. The site is built with plain HTML, CSS and JavaScript.
+This repository contains a simple static website demonstrating a basic Progressive Web App (PWA) setup for a fictional business. The site is built with plain HTML, CSS and JavaScript. A sample `styles.scss` file is included if you wish to use a SCSS workflow.
 
 ## Site Highlights
 
@@ -23,9 +23,30 @@ python3 -m http.server 8000
 npx http-server -p 8000
 ```
 
+### Building CSS from SCSS
+If you prefer using SCSS, run the following command and then optionally autoprefix the result:
+
+```sh
+sass styles.scss styles.css --no-source-map
+npx autoprefixer styles.css -o styles.css
+```
+
 ## PWA features
 
 
 - **Theme color** meta tag customizes the browser UI when the site is installed or opened on mobile.
 
 These features illustrate how to turn a regular static page into a lightweight PWA.
+
+### Customizing the hero video
+
+The background video in the hero section can load either an MP4 file or a YouTube video. Update the `data-video` or `data-youtube` attribute on the `#hero-media` element in `index.html` to change the source. A mute/unmute button lets visitors toggle audio.
+
+## Recent Updates
+
+- Relaxed Content Security Policy to allow loading Google Fonts and hero video
+- Added a scroll progress indicator for long pages
+- New masonry gallery and animated skills section
+- Multi-step contact form with inline validation
+- High-contrast theme option and Lottie-powered toggle
+- Hero video now supports YouTube links and includes a mute/unmute button

--- a/index.html
+++ b/index.html
@@ -90,7 +90,7 @@
   </nav>
   <div class="hero-bg">
     <div id="hero-media" data-video="https://www.w3schools.com/html/mov_bbb.mp4"></div>
-    <button class="video-mute" aria-label="Toggle video sound">🔇</button>
+    <button class="video-mute" aria-label="Toggle video sound" aria-pressed="true">🔇</button>
   </div>
   <div class="hero-content">
     <h1>Grow Your Business with Us</h1>

--- a/index.html
+++ b/index.html
@@ -21,13 +21,18 @@
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="default">
   <meta name="color-scheme" content="light dark">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' https://placehold.co data:; style-src 'self'; script-src 'self';">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' https://placehold.co data:; style-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; media-src 'self' https://www.w3schools.com https://www.youtube.com https://www.youtube-nocookie.com https://youtu.be; frame-src https://www.youtube.com https://www.youtube-nocookie.com; script-src 'self' https://www.youtube.com;">
   <link rel="icon" type="image/png" sizes="96x96" href="https://placehold.co/96x96">
   <link rel="apple-touch-icon" href="https://placehold.co/180x180">
   <link rel="manifest" href="manifest.json">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link rel="stylesheet" href="styles.css">
+  <link rel="prefetch" href="https://placehold.co/800x600" as="image">
+  <link rel="preload" href="styles.css" as="style" onload="this.rel='stylesheet'">
+  <noscript><link rel="stylesheet" href="styles.css"></noscript>
+  <script src="https://unpkg.com/lottie-web@5.9.4/build/player/lottie.min.js" defer></script>
+  <script src="https://www.youtube.com/iframe_api" defer></script>
+
   <script defer src="scripts.js"></script>
   <script type="application/ld+json">
   {
@@ -49,7 +54,11 @@
   </script>
 </head>
 <body>
+<div id="spinner" class="spinner"><div class="loader"></div></div>
 <a href="#main" class="skip-link">Skip to main content</a>
+<div id="theme-lottie" class="theme-lottie" aria-hidden="true"></div>
+
+<div class="scroll-progress" aria-hidden="true"></div>
 <header class="hero" id="top">
   <nav class="nav" aria-label="Main Navigation">
     <button class="nav-toggle" aria-label="Toggle navigation" aria-expanded="false">&#9776;</button>
@@ -59,12 +68,35 @@
       <li><a href="#about">About</a></li>
       <li><a href="#team">Team</a></li>
       <li><a href="#testimonials">Testimonials</a></li>
+      <li><a href="#gallery">Gallery</a></li>
+      <li><a href="#skills">Skills</a></li>
       <li><a href="#contact">Contact</a></li>
       <li><a href="#newsletter">Newsletter</a></li>
+      <li class="has-mega"><a href="#">Resources</a>
+        <div class="mega-menu" aria-label="Mega menu">
+          <ul>
+            <li><a href="#">Docs</a></li>
+            <li><a href="#">Blog</a></li>
+            <li><a href="#">Case Studies</a></li>
+          </ul>
+          <ul>
+            <li><a href="#">Tutorials</a></li>
+            <li><a href="#">Guides</a></li>
+            <li><a href="#">Support</a></li>
+          </ul>
+        </div>
+      </li>
     </ul>
   </nav>
+  <div class="hero-bg">
+    <div id="hero-media" data-video="https://www.w3schools.com/html/mov_bbb.mp4"></div>
+    <button class="video-mute" aria-label="Toggle video sound">🔇</button>
+  </div>
   <div class="hero-content">
     <h1>Grow Your Business with Us</h1>
+    <svg class="pulse" width="80" height="80" viewBox="0 0 24 24" aria-hidden="true">
+      <circle cx="12" cy="12" r="10" stroke="currentColor" fill="none"/>
+    </svg>
     <p>We provide elite solutions for tomorrow's market.</p>
     <a href="#contact" class="cta">Get Started</a>
   </div>
@@ -94,7 +126,9 @@
     <div class="container">
       <div class="about-image">
         <picture>
-          <img src="https://placehold.co/800x600" alt="About us" loading="lazy" width="800" height="600">
+          <img src="https://placehold.co/800x600" alt="About us" loading="lazy"
+               srcset="https://placehold.co/400x300 400w, https://placehold.co/800x600 800w"
+               sizes="(max-width: 600px) 100vw, 800px" width="800" height="600">
         </picture>
       </div>
       <div class="about-text">
@@ -108,15 +142,21 @@
       <h2>What Our Clients Say</h2>
       <div class="testimonial-grid">
         <figure>
-          <img src="https://placehold.co/400" alt="Customer 1" loading="lazy" width="400" height="400">
+          <img src="https://placehold.co/400" alt="Customer 1" loading="lazy"
+               srcset="https://placehold.co/200 200w, https://placehold.co/400 400w"
+               sizes="(max-width: 600px) 100vw, 400px" width="400" height="400">
           <figcaption>"Outstanding service!"</figcaption>
         </figure>
         <figure>
-          <img src="https://placehold.co/400" alt="Customer 2" loading="lazy" width="400" height="400">
+          <img src="https://placehold.co/400" alt="Customer 2" loading="lazy"
+               srcset="https://placehold.co/200 200w, https://placehold.co/400 400w"
+               sizes="(max-width: 600px) 100vw, 400px" width="400" height="400">
           <figcaption>"Truly professional."</figcaption>
         </figure>
         <figure>
-          <img src="https://placehold.co/400" alt="Customer 3" loading="lazy" width="400" height="400">
+          <img src="https://placehold.co/400" alt="Customer 3" loading="lazy"
+               srcset="https://placehold.co/200 200w, https://placehold.co/400 400w"
+               sizes="(max-width: 600px) 100vw, 400px" width="400" height="400">
           <figcaption>"Highly recommended!"</figcaption>
         </figure>
       </div>
@@ -127,38 +167,62 @@
       <h2>Meet the Team</h2>
       <div class="team-grid">
         <figure>
-          <img src="https://placehold.co/200" alt="Team member 1" loading="lazy" width="200" height="200">
+          <img src="https://placehold.co/200" alt="Team member 1" loading="lazy"
+               srcset="https://placehold.co/100 100w, https://placehold.co/200 200w"
+               sizes="(max-width: 600px) 50vw, 200px" width="200" height="200">
           <figcaption>Jane Doe - CEO</figcaption>
         </figure>
         <figure>
-          <img src="https://placehold.co/200" alt="Team member 2" loading="lazy" width="200" height="200">
+          <img src="https://placehold.co/200" alt="Team member 2" loading="lazy"
+               srcset="https://placehold.co/100 100w, https://placehold.co/200 200w"
+               sizes="(max-width: 600px) 50vw, 200px" width="200" height="200">
           <figcaption>John Smith - CTO</figcaption>
         </figure>
         <figure>
-          <img src="https://placehold.co/200" alt="Team member 3" loading="lazy" width="200" height="200">
+          <img src="https://placehold.co/200" alt="Team member 3" loading="lazy"
+               srcset="https://placehold.co/100 100w, https://placehold.co/200 200w"
+               sizes="(max-width: 600px) 50vw, 200px" width="200" height="200">
           <figcaption>Mary Johnson - CFO</figcaption>
         </figure>
       </div>
     </div>
   </section>
+  <section id="gallery" class="gallery">
+    <div class="container">
+      <h2>Gallery</h2>
+      <div class="masonry">
+        <img data-src="https://placehold.co/600x400" alt="Gallery item 1" width="600" height="400">
+        <img data-src="https://placehold.co/400x600" alt="Gallery item 2" width="400" height="600">
+        <img data-src="https://placehold.co/500x500" alt="Gallery item 3" width="500" height="500">
+      </div>
+    </div>
+  </section>
+  <section id="skills" class="skills">
+    <div class="container">
+      <h2>Our Skills</h2>
+      <div class="skill"><span class="skill-label">Consulting</span><div class="skill-bar"><div class="skill-progress" data-value="90"></div></div></div>
+      <div class="skill"><span class="skill-label">Development</span><div class="skill-bar"><div class="skill-progress" data-value="80"></div></div></div>
+      <div class="skill"><span class="skill-label">Support</span><div class="skill-bar"><div class="skill-progress" data-value="85"></div></div></div>
+    </div>
+  </section>
   <section id="contact" class="contact">
     <div class="container">
       <h2>Contact Us</h2>
-      <form action="https://formspree.io/f/mayvlzgv" method="POST">
-        <label>
-          Name
-          <input type="text" name="name" required>
-        </label>
-        <label>
-          Email
-          <input type="email" name="email" required>
-        </label>
-        <label>
-          Message
-          <textarea name="message" rows="5" required></textarea>
-        </label>
-        <button type="submit" class="cta">Send</button>
+      <form id="contact-form" action="https://formspree.io/f/mayvlzgv" method="POST">
+        <div class="form-step">
+          <label class="float"> <input type="text" name="name" placeholder=" " required><span>Name</span></label>
+          <label class="float"> <input type="email" name="email" placeholder=" " required><span>Email</span></label>
+          <button type="button" class="next cta">Next</button>
+        </div>
+        <div class="form-step" hidden>
+          <label class="float"> <textarea name="message" rows="5" placeholder=" " required></textarea><span>Message</span></label>
+          <label class="float"> <select name="service" required><option value="" disabled selected>Choose service</option><option>Consulting</option><option>Development</option></select><span>Service</span></label>
+          <label class="checkbox"><input type="checkbox" name="agree" required><span>I agree to terms</span></label>
+          <div class="form-actions"><button type="button" class="prev cta">Back</button><button type="submit" class="cta">Send</button></div>
+        </div>
+        <progress class="form-progress" value="1" max="2"></progress>
       </form>
+      <p id="contact-message" hidden></p>
     </div>
   </section>
   <section id="newsletter" class="newsletter">
@@ -192,8 +256,12 @@
   </div>
   <p>&copy; <span id="year"></span> Acme Corp. All rights reserved.</p>
 </footer>
-<button class="mode-toggle" aria-label="Toggle dark mode">🌓</button>
+<button class="mode-toggle" aria-label="Toggle theme">🌓</button>
 <button class="scroll-top" aria-label="Back to top">↑</button>
+<div id="install-banner" class="install-banner" hidden>
+  <button id="install-btn" class="cta">Add to Home Screen</button>
+</div>
+<div id="network-status" class="network-status" aria-live="polite" hidden>Offline</div>
 <script>
   document.getElementById('year').textContent = new Date().getFullYear();
 </script>

--- a/manifest.json
+++ b/manifest.json
@@ -22,4 +22,15 @@
       "type": "image/png"
     }
   ]
+  ,
+  "share_target": {
+    "action": "/share-target",
+    "method": "POST",
+    "enctype": "multipart/form-data",
+    "params": {
+      "title": "shared-title",
+      "text": "shared-text",
+      "url": "shared-url"
+    }
+  }
 }

--- a/scripts.js
+++ b/scripts.js
@@ -50,10 +50,19 @@ if(videoMuteBtn){
   videoMuteBtn.addEventListener('click',()=>{
     if(heroVideo){
       heroVideo.muted=!heroVideo.muted;
-      videoMuteBtn.textContent=heroVideo.muted?'🔇':'🔊';
+      const muted=heroVideo.muted;
+      videoMuteBtn.textContent=muted?'🔇':'🔊';
+      videoMuteBtn.setAttribute('aria-pressed',muted);
     }else if(heroYTPlayer){
-      if(heroYTPlayer.isMuted()){heroYTPlayer.unMute();videoMuteBtn.textContent='🔊';}
-      else{heroYTPlayer.mute();videoMuteBtn.textContent='🔇';}
+      if(heroYTPlayer.isMuted()){
+        heroYTPlayer.unMute();
+        videoMuteBtn.textContent='🔊';
+        videoMuteBtn.setAttribute('aria-pressed','false');
+      }else{
+        heroYTPlayer.mute();
+        videoMuteBtn.textContent='🔇';
+        videoMuteBtn.setAttribute('aria-pressed','true');
+      }
     }
   });
 }

--- a/scripts.js
+++ b/scripts.js
@@ -1,6 +1,64 @@
 // Mobile nav toggle
 const navToggle = document.querySelector('.nav-toggle');
 const navMenu = document.querySelector('.nav-menu');
+const spinner = document.getElementById('spinner');
+
+// Hero media setup
+const heroMedia = document.getElementById('hero-media');
+const videoMuteBtn = document.querySelector('.video-mute');
+let heroVideo = null;
+let heroYTPlayer = null;
+
+function loadYouTubeAPI(){
+  const tag=document.createElement('script');
+  tag.src='https://www.youtube.com/iframe_api';
+  document.head.appendChild(tag);
+}
+
+function initHeroMedia(){
+  if(!heroMedia) return;
+  if(window.matchMedia('(prefers-reduced-motion: reduce)').matches){
+    heroMedia.style.display='none';
+    if(videoMuteBtn) videoMuteBtn.style.display='none';
+    return;
+  }
+  if(heroMedia.dataset.youtube){
+    loadYouTubeAPI();
+  }else if(heroMedia.dataset.video){
+    heroVideo=document.createElement('video');
+    heroVideo.className='hero-video';
+    heroVideo.autoplay=true;
+    heroVideo.loop=true;
+    heroVideo.playsInline=true;
+    heroVideo.muted=true;
+    heroVideo.innerHTML=`<source src="${heroMedia.dataset.video}" type="${heroMedia.dataset.type||'video/mp4'}">`;
+    heroMedia.appendChild(heroVideo);
+  }
+}
+
+window.initHeroMedia=initHeroMedia;
+document.addEventListener('DOMContentLoaded',initHeroMedia);
+
+function onYouTubeIframeAPIReady(){
+  if(!heroMedia||!heroMedia.dataset.youtube) return;
+  const id=heroMedia.dataset.youtube;
+  heroYTPlayer=new YT.Player(heroMedia,{videoId:id,playerVars:{autoplay:1,loop:1,playlist:id,controls:0,playsinline:1,modestbranding:1,showinfo:0,mute:1},events:{onReady:e=>e.target.playVideo()}});
+}
+window.onYouTubeIframeAPIReady=onYouTubeIframeAPIReady;
+
+if(videoMuteBtn){
+  videoMuteBtn.addEventListener('click',()=>{
+    if(heroVideo){
+      heroVideo.muted=!heroVideo.muted;
+      videoMuteBtn.textContent=heroVideo.muted?'🔇':'🔊';
+    }else if(heroYTPlayer){
+      if(heroYTPlayer.isMuted()){heroYTPlayer.unMute();videoMuteBtn.textContent='🔊';}
+      else{heroYTPlayer.mute();videoMuteBtn.textContent='🔇';}
+    }
+  });
+}
+document.addEventListener('DOMContentLoaded', ()=> spinner.hidden=false);
+window.addEventListener('load', ()=> spinner.hidden=true);
 navToggle.addEventListener('click', () => {
   const expanded = navToggle.getAttribute('aria-expanded') === 'true';
   const newExpanded = !expanded;
@@ -18,18 +76,23 @@ document.querySelectorAll('.nav-menu a').forEach(link => {
   });
 });
 
-// Dark mode toggle
+// Theme toggle with high contrast option
 const modeToggle = document.querySelector('.mode-toggle');
+const themes = ['light','dark','contrast'];
+let themeIndex = themes.indexOf(localStorage.getItem('theme'));
+if(themeIndex === -1) themeIndex = 0;
+applyTheme(themeIndex);
 
-// Apply saved preference on load
-const savedTheme = localStorage.getItem('theme');
-if (savedTheme === 'dark') {
-  document.documentElement.classList.add('dark-mode');
+function applyTheme(i){
+  document.documentElement.classList.toggle('dark-mode', themes[i]==='dark');
+  document.documentElement.classList.toggle('high-contrast', themes[i]==='contrast');
 }
 
 modeToggle.addEventListener('click', () => {
-  const isDark = document.documentElement.classList.toggle('dark-mode');
-  localStorage.setItem('theme', isDark ? 'dark' : 'light');
+  themeIndex = (themeIndex + 1) % themes.length;
+  applyTheme(themeIndex);
+  localStorage.setItem('theme', themes[themeIndex]);
+  lottieAnim && lottieAnim.goToAndPlay(0,true);
 });
 
 // Intersection animations
@@ -37,6 +100,9 @@ const observer = new IntersectionObserver(entries => {
   entries.forEach(entry => {
     if (entry.isIntersecting) {
       entry.target.classList.add('show');
+      if(entry.target.classList.contains('skill-progress')){
+        entry.target.style.width = entry.target.dataset.value + '%';
+      }
     }
   });
 }, {threshold: 0.1});
@@ -45,7 +111,66 @@ document.querySelectorAll('.card, .about, .testimonial-grid figure, .contact for
   observer.observe(el);
 });
 
-if('serviceWorker' in navigator){navigator.serviceWorker.register('sw.js');}
+// Lazy load images
+const lazyImages = document.querySelectorAll('img[data-src]');
+const imgObserver = new IntersectionObserver(entries => {
+  entries.forEach(entry => {
+    if(entry.isIntersecting){
+      const img = entry.target;
+      img.src = img.dataset.src;
+      img.removeAttribute('data-src');
+      imgObserver.unobserve(img);
+    }
+  });
+});
+lazyImages.forEach(img => imgObserver.observe(img));
+
+// Animate skill bars
+document.querySelectorAll('.skill-progress').forEach(bar => {
+  observer.observe(bar);
+});
+let swRegister;
+if("serviceWorker" in navigator){
+  navigator.serviceWorker.register("sw.js").then(reg=>{
+    swRegister=reg;
+    setupPush(reg);
+  });
+}
+
+// Collapse sticky nav on scroll down
+const navBar = document.querySelector(".nav");
+let lastScrollY = window.scrollY;
+if(navBar){
+  window.addEventListener("scroll", () => {
+    if(window.scrollY > lastScrollY && window.scrollY > 50){
+      navBar.classList.add("nav-collapsed");
+    } else {
+      navBar.classList.remove("nav-collapsed");
+    }
+    lastScrollY = window.scrollY;
+  });
+}
+
+// Parallax hero background
+const hero = document.querySelector(".hero");
+if(hero){
+  window.addEventListener("scroll", () => {
+    const offset = window.scrollY * 0.5;
+    hero.style.backgroundPositionY = `-${offset}px`;
+  });
+}
+
+// Scroll progress indicator
+const progressBar = document.querySelector(".scroll-progress");
+if(progressBar){
+  window.addEventListener("scroll", () => {
+    const max = document.body.scrollHeight - window.innerHeight;
+    const percent = Math.min(100, (window.scrollY / max) * 100);
+    progressBar.style.width = `${percent}%`;
+  });
+}
+
+
 
 // Scroll to top button
 const scrollBtn = document.querySelector('.scroll-top');
@@ -68,8 +193,138 @@ if(newsletterForm){
   const msg = document.getElementById('newsletter-message');
   newsletterForm.addEventListener('submit', e => {
     e.preventDefault();
+    const data = new FormData(newsletterForm);
+    if(navigator.onLine){
+      fetch('/newsletter', {method:'POST', body:data});
+      msg.textContent = 'Thank you for subscribing!';
+    }else{
+      saveRecord(formDB,'forms',{url:'/newsletter',data:Object.fromEntries(data)});
+      swRegister && swRegister.sync && swRegister.sync.register('sync-forms');
+      msg.textContent = 'Saved offline. We\'ll subscribe you when back online.';
+    }
     newsletterForm.reset();
     msg.hidden = false;
+  });
+}
+
+const contactForm = document.getElementById('contact-form');
+if(contactForm){
+  const steps = contactForm.querySelectorAll('.form-step');
+  const nextBtn = contactForm.querySelector('.next');
+  const prevBtn = contactForm.querySelector('.prev');
+  const progress = contactForm.querySelector('.form-progress');
+  let current = 0;
+  function showStep(i){
+    steps.forEach((s,idx)=>{s.hidden = idx!==i;});
+    progress.value = i+1;
+  }
+  showStep(0);
+  nextBtn.addEventListener('click',()=>{
+    const valid=[...steps[0].querySelectorAll('input')].every(i=>i.reportValidity());
+    if(valid){ current=1; showStep(1); }
+  });
+  prevBtn.addEventListener('click',()=>{current=0;showStep(0);});
+  contactForm.addEventListener('submit',e=>{
+    e.preventDefault();
+    const data=new FormData(contactForm);
+    const msg=document.getElementById('contact-message');
+    if(navigator.onLine){
+      fetch(contactForm.action,{method:'POST',body:data});
+      msg.textContent='Message sent!';
+    }else{
+      saveRecord(formDB,'forms',{url:contactForm.action,data:Object.fromEntries(data)});
+      swRegister && swRegister.sync && swRegister.sync.register('sync-forms');
+      msg.textContent='Saved offline and will send later.';
+    }
+    contactForm.reset();
+    showStep(0);
+    msg.hidden=false;
+  });
+  contactForm.querySelectorAll('input,textarea,select').forEach(el=>{
+    el.addEventListener('invalid',()=>el.classList.add('invalid'));
+    el.addEventListener('input',()=>el.classList.remove('invalid'));
+  });
+}
+
+// Install banner
+let deferredPrompt;
+const installBanner=document.getElementById('install-banner');
+const installBtn=document.getElementById('install-btn');
+window.addEventListener('beforeinstallprompt',e=>{
+  e.preventDefault();
+  deferredPrompt=e;
+  installBanner.hidden=false;
+});
+installBtn.addEventListener('click',()=>{
+  if(deferredPrompt){
+    deferredPrompt.prompt();
+    deferredPrompt.userChoice.finally(()=>{
+      installBanner.hidden=true;
+      deferredPrompt=null;
+    });
+  }
+});
+
+// Network status UI
+const networkStatus=document.getElementById('network-status');
+function updateStatus(){
+  networkStatus.hidden=navigator.onLine;
+}
+window.addEventListener('online',updateStatus);
+window.addEventListener('offline',updateStatus);
+updateStatus();
+
+// IndexedDB helpers
+function openDB(name,store){
+  return new Promise((resolve,reject)=>{
+    const req=indexedDB.open(name,1);
+    req.onupgradeneeded=()=>req.result.createObjectStore(store,{autoIncrement:true});
+    req.onsuccess=()=>resolve(req.result);
+    req.onerror=()=>reject(req.error);
+  });
+}
+const formDB=openDB('form-store','forms');
+const analyticsDB=openDB('analytics-store','events');
+function saveRecord(dbPromise,store,data){
+  dbPromise.then(db=>{
+    const tx=db.transaction(store,'readwrite');
+    tx.objectStore(store).add(data);
+  });
+}
+
+// Background analytics
+function sendAnalytics(data){
+  if(navigator.onLine){
+    fetch('/analytics',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(data)});
+  }else{
+    saveRecord(analyticsDB,'events',data);
+    swRegister && swRegister.sync && swRegister.sync.register('sync-analytics');
+  }
+}
+sendAnalytics({event:'pageview',url:location.href});
+
+// Lottie animation for theme toggle
+const lottieContainer=document.getElementById('theme-lottie');
+let lottieAnim=null;
+if(lottieContainer && window.lottie){
+  lottieAnim=window.lottie.loadAnimation({
+    container:lottieContainer,
+    renderer:'svg',
+    loop:false,
+    autoplay:false,
+    path:'https://assets9.lottiefiles.com/temp/lf20_oGlWy5.json'
+  });
+}
+
+// Push notifications
+function setupPush(reg){
+  if(!('PushManager' in window))return;
+  Notification.requestPermission().then(per=>{
+    if(per==='granted'){
+      reg.pushManager.subscribe({userVisibleOnly:true}).then(sub=>{
+        fetch('/subscribe',{method:'POST',body:JSON.stringify(sub)});
+      });
+    }
   });
 }
 

--- a/styles.css
+++ b/styles.css
@@ -1,19 +1,33 @@
 @import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;700&display=swap');
 
+/* Reset */
+*,
+*::before,
+*::after {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+html { line-height: 1.15; -webkit-text-size-adjust: 100%; }
+
 /* Variables */
 :root {
   --font-family: 'Poppins', 'DejaVu Sans', system-ui, sans-serif;
-  --color-bg: #f5f5f5;
-  --color-text: #333;
-  --color-accent: #16a085;
-  --color-dark-bg: #1e1e1e;
-  --color-dark-text: #eee;
+  --color-bg: #ffffff;
+  --color-text: #222222;
+  --color-primary: #0d6efd;
+  --color-accent: var(--color-primary);
+  --color-dark-bg: #121212;
+  --color-dark-text: #f1f1f1;
+  --icon-color: currentColor;
   --transition-fast: 0.3s ease;
+  --transition-slow: 0.6s ease;
 }
 @media (prefers-color-scheme: dark) {
   :root {
     --color-bg: var(--color-dark-bg);
     --color-text: var(--color-dark-text);
+    --color-accent: #1abc9c;
   }
 }
 html {
@@ -31,7 +45,8 @@ body {
 
 .container {
   max-width: 1200px;
-  margin: 0 auto;
+  margin-inline: auto;
+  padding-inline: clamp(1rem, 5vw, 2rem);
 }
 a {color: var(--color-accent); text-decoration: none;}
 a:hover {text-decoration: underline;}
@@ -54,29 +69,89 @@ a:hover {text-decoration: underline;}
   z-index:1000;
 }
 .nav {
+  position: -webkit-sticky;
+  position: sticky;
+  top: 0;
+  z-index: 100;
   display: flex;
   justify-content: space-between;
   align-items: center;
   padding: 1rem;
+  background: var(--color-bg);
+  transition: transform var(--transition-fast);
 }
-.nav-menu {display: flex; list-style: none; margin:0; padding:0;}
-.nav-menu li {margin-left: 1rem;}
+
+.nav.nav-collapsed {
+  transform: translateY(-100%);
+}
+.nav-menu {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  list-style: none;
+  margin:0;
+  padding:0;
+}
+.nav-menu li {margin-inline-start: 1rem;}
+.has-mega {position:relative;}
+.mega-menu {
+  display:none;
+  position:absolute;
+  left:0;
+  right:0;
+  top:100%;
+  background:var(--color-bg);
+  padding:1rem;
+  box-shadow:0 2px 8px rgba(0,0,0,0.15);
+  width:100%;
+}
+@media (min-width: 1024px) {
+  .has-mega:hover .mega-menu {display:grid;}
+  .mega-menu {grid-template-columns:repeat(2,minmax(0,1fr)); gap:1rem;}
+}
 .nav-toggle {display:none;background:none;border:none;font-size:2rem;color:var(--color-text);}
 @media (max-width: 768px) {
-  .nav-menu {flex-direction: column; display:none; background: var(--color-bg); position:absolute; top:60px; right:1rem; padding:1rem; box-shadow:0 2px 5px rgba(0,0,0,0.1);}
-  .nav-menu.show {display:flex;}
+  .nav-menu {
+    -webkit-box-orient: vertical;
+    -webkit-box-direction: normal;
+    -ms-flex-direction: column;
+    flex-direction: column;
+    display:none;
+    background: var(--color-bg);
+    position:absolute;
+    top:60px;
+    right:1rem;
+    padding:1rem;
+    box-shadow:0 2px 5px rgba(0,0,0,0.1);
+    transform: translateX(100%);
+    transition: transform var(--transition-fast);
+  }
+  .nav-menu.show {
+    display:block;
+    transform: translateX(0);
+  }
   .nav-toggle {display:block;}
 }
 .hero {
   background: url('https://placehold.co/1920x1080') center/cover no-repeat;
   min-height: 100dvh;
+  display:-webkit-box;
+  display:-ms-flexbox;
   display:flex;
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+  -ms-flex-direction: column;
   flex-direction:column;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
   justify-content:center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
   align-items:center;
   text-align:center;
   color:#fff;
   position:relative;
+  background-attachment: fixed;
 }
 
 .hero::before {
@@ -87,29 +162,88 @@ a:hover {text-decoration: underline;}
   z-index:0;
   pointer-events:none;
 }
+.hero-bg {
+  position:absolute;
+  inset:0;
+  overflow:hidden;
+  z-index:0;
+}
+.hero-video {
+  width:100%;
+  height:100%;
+  object-fit:cover;
+}
+.video-mute{
+  position:absolute;
+  bottom:1rem;
+  left:1rem;
+  width:2.5rem;
+  height:2.5rem;
+  border:none;
+  border-radius:50%;
+  background:rgba(0,0,0,0.5);
+  color:#fff;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  cursor:pointer;
+  z-index:1;
+}
+.video-mute:focus-visible{outline:3px solid var(--color-accent);}
 
 .hero-content{position:relative;z-index:1;}
 .hero .cta {background: var(--color-accent); color:white; padding:0.75rem 1.5rem; border-radius:4px; display:inline-block; margin-top:1rem; transition:background var(--transition-fast);} 
 .hero .cta:hover {background:#128066;}
-.features {padding:4rem 1rem;}
-.card-grid {display:grid; grid-template-columns:repeat(auto-fit,minmax(200px,1fr)); gap:1rem;}
+.features {padding-block: min(10vh,4rem); padding-inline: 1rem;}
+.card-grid {
+  display:-ms-grid;
+  display:grid;
+  grid-template-columns:repeat(auto-fit,minmax(200px,1fr));
+  gap:1rem;
+}
 .card {background:white; padding:1rem; border-radius:8px; box-shadow:0 2px 5px rgba(0,0,0,0.1); transition:transform var(--transition-fast);} 
 .card:hover {transform:translateY(-5px);} 
-.about {display:grid; grid-template-columns:1fr 1fr; align-items:center; gap:2rem; padding:4rem 1rem;} 
+.about {
+  display:-ms-grid;
+  display:grid;
+  grid-template-columns:1fr 1fr;
+  align-items:center;
+  gap:2rem;
+  padding-block: min(10vh,4rem);
+  padding-inline:1rem;
+}
 .about-image img {width:100%; height:auto; border-radius:8px;}
 @media (max-width: 768px){
   .about {grid-template-columns:1fr;}
 }
-.testimonials {padding:4rem 1rem; background: #fafafa;}
-.testimonial-grid {display:grid; grid-template-columns:repeat(auto-fit,minmax(200px,1fr)); gap:1rem; text-align:center;}
+.testimonials {padding-block: min(10vh,4rem); padding-inline:1rem; background: #fafafa;}
+.testimonial-grid {
+  display:-ms-grid;
+  display:grid;
+  grid-template-columns:repeat(auto-fit,minmax(200px,1fr));
+  gap:1rem;
+  text-align:center;
+}
 .testimonial-grid img {border-radius:50%; width:150px; height:150px; object-fit:cover; margin:auto;}
-.contact {padding:4rem 1rem;}
-.contact form {display:grid; gap:1rem; max-width:500px; margin:auto;}
+.contact {padding-block: min(10vh,4rem); padding-inline:1rem;}
+.contact form {
+  display:-ms-grid;
+  display:grid;
+  gap:1rem;
+  max-width:500px;
+  margin:auto;
+}
 .contact input, .contact textarea {width:100%; padding:0.5rem; border:1px solid #ccc; border-radius:4px;}
 .contact button {background:var(--color-accent); color:white; border:none; padding:0.75rem; border-radius:4px; cursor:pointer; transition:background var(--transition-fast);} 
 .contact button:hover {background:#128066;}
-.services,.team,.newsletter{padding:4rem 1rem;}
-.team-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(200px,1fr));gap:1rem;text-align:center;}
+.services,.team,.newsletter{padding-block:min(10vh,4rem); padding-inline:1rem;}
+.team-grid{
+  display:-ms-grid;
+  display:grid;
+  grid-template-columns:repeat(auto-fit,minmax(200px,1fr));
+  gap:1rem;
+  text-align:center;
+}
 .team-grid img{border-radius:50%;width:150px;height:150px;object-fit:cover;margin:auto;}
 .newsletter form{display:flex;gap:0.5rem;justify-content:center;flex-wrap:wrap;max-width:500px;margin:auto;}
 .newsletter input{padding:0.5rem;border:1px solid #ccc;border-radius:4px;flex:1 1 200px;}
@@ -117,11 +251,16 @@ a:hover {text-decoration: underline;}
 .newsletter button:hover{background:#128066;}
 .footer {text-align:center; padding:2rem 1rem; background:#222; color:#fff;}
 .footer a {color:#fff; margin:0 0.5rem;}
-.footer svg {width:1.5rem; height:1.5rem; vertical-align:middle;}
+.footer svg {width:1.5rem; height:1.5rem; vertical-align:middle; stroke: var(--icon-color);}
+
 .mode-toggle {position:fixed; bottom:1rem; right:1rem; background:var(--color-accent); border:none; color:#fff; padding:0.5rem; border-radius:50%; font-size:1.2rem; cursor:pointer;}
+
+.scroll-progress{position:fixed;top:0;left:0;height:4px;width:0;background:var(--color-accent);z-index:200;transition:width var(--transition-fast) linear;}
 
 .scroll-top{position:fixed;bottom:4rem;right:1rem;background:var(--color-accent);border:none;color:#fff;padding:0.5rem;border-radius:50%;font-size:1.2rem;cursor:pointer;display:none;}
 .scroll-top.show{display:block;}
+.network-status{position:fixed;bottom:0;left:0;right:0;background:#e74c3c;color:#fff;text-align:center;padding:0.5rem;font-size:0.9rem;}
+.install-banner{position:fixed;bottom:0;left:0;right:0;background:var(--color-accent);color:#fff;text-align:center;padding:0.5rem;}
 
 .dark-mode{--color-bg:var(--color-dark-bg);--color-text:var(--color-dark-text);}
 
@@ -178,4 +317,70 @@ a:hover {text-decoration: underline;}
   outline: 3px solid var(--color-text);
   outline-offset: 2px;
 }
+
+/* Masonry gallery */
+.masonry {
+  column-count: 3;
+  column-gap: 1rem;
+}
+.masonry img {
+  width: 100%;
+  margin-bottom: 1rem;
+  break-inside: avoid;
+  border-radius: 4px;
+}
+
+/* Skills progress */
+.skill {margin-bottom:1rem;}
+.skill-bar {background:#eee;border-radius:4px;overflow:hidden;height:0.5rem;}
+.skill-progress {background:var(--color-accent);width:0;height:100%;transition:width var(--transition-slow);}
+
+/* Floating labels */
+label.float {position:relative;display:block;margin-bottom:1rem;}
+label.float input,
+label.float textarea,
+label.float select {width:100%;padding:1rem 0.5rem 0.25rem;border:1px solid #ccc;border-radius:4px;background:none;}
+label.float span {position:absolute;left:0.5rem;top:0.75rem;transition:transform var(--transition-fast),font-size var(--transition-fast);pointer-events:none;color:#666;}
+label.float input:focus+span,
+label.float input:not(:placeholder-shown)+span,
+label.float textarea:focus+span,
+label.float textarea:not(:placeholder-shown)+span,
+label.float select:focus+span,
+label.float select:not([value=""])+span {
+  transform:translateY(-1.2rem);
+  font-size:0.75rem;
+  color:var(--color-text);
+}
+
+/* Custom checkbox */
+.checkbox {display:flex;align-items:center;gap:0.5rem;margin-bottom:1rem;}
+.checkbox input {appearance:none;width:1rem;height:1rem;border:1px solid #ccc;border-radius:3px;position:relative;}
+.checkbox input:checked::before {content:"";position:absolute;inset:2px;background:var(--color-accent);}
+
+/* Select styling */
+select {appearance:none;background:url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 6"><path d="M0 0l5 6 5-6z" fill="%23333"/></svg>') no-repeat right 0.5rem center/0.6rem;border:1px solid #ccc;border-radius:4px;padding:0.5rem;padding-right:1.5rem;}
+
+/* Form progress */
+.form-progress {width:100%;margin-top:0.5rem;height:0.5rem;}
+
+/* Spinner */
+.spinner {position:fixed;inset:0;background:rgba(255,255,255,0.8);display:flex;justify-content:center;align-items:center;z-index:300;}
+.spinner .loader {width:2rem;height:2rem;border:3px solid var(--color-accent);border-right-color:transparent;border-radius:50%;animation:spin 1s linear infinite;}
+
+@keyframes spin {to{transform:rotate(360deg);}}
+
+.pulse {animation:pulse 2s infinite ease-in-out;}
+@keyframes pulse {0%{transform:scale(1);}50%{transform:scale(1.2);}100%{transform:scale(1);}}
+
+.rocket {margin-bottom:1rem;animation:float 4s ease-in-out infinite;}
+@keyframes float {0%,100%{transform:translateY(0);}50%{transform:translateY(-10px);}}
+
+/* High contrast theme */
+.high-contrast {
+  --color-bg:#000;
+  --color-text:#ff0;
+  --color-accent:#f0f;
+}
+
+.invalid {border-color:#e74c3c;}
 

--- a/styles.css
+++ b/styles.css
@@ -19,6 +19,7 @@ html { line-height: 1.15; -webkit-text-size-adjust: 100%; }
   --color-accent: var(--color-primary);
   --color-dark-bg: #121212;
   --color-dark-text: #f1f1f1;
+  --color-card-bg: #ffffff;
   --icon-color: currentColor;
   --transition-fast: 0.3s ease;
   --transition-slow: 0.6s ease;
@@ -27,6 +28,7 @@ html { line-height: 1.15; -webkit-text-size-adjust: 100%; }
   :root {
     --color-bg: var(--color-dark-bg);
     --color-text: var(--color-dark-text);
+    --color-card-bg: #333333;
     --color-accent: #1abc9c;
   }
 }
@@ -201,7 +203,7 @@ a:hover {text-decoration: underline;}
   grid-template-columns:repeat(auto-fit,minmax(200px,1fr));
   gap:1rem;
 }
-.card {background:white; padding:1rem; border-radius:8px; box-shadow:0 2px 5px rgba(0,0,0,0.1); transition:transform var(--transition-fast);} 
+.card {background:var(--color-card-bg); padding:1rem; border-radius:8px; box-shadow:0 2px 5px rgba(0,0,0,0.1); transition:transform var(--transition-fast);}
 .card:hover {transform:translateY(-5px);} 
 .about {
   display:-ms-grid;
@@ -279,7 +281,7 @@ a:hover {text-decoration: underline;}
   background:#16a085;
 }
 
-.dark-mode .card {background:#333; color:var(--color-dark-text);}
+.dark-mode .card {color:var(--color-dark-text);}
 
 .card,.about,.testimonial-grid figure,.contact form,.team-grid figure,.newsletter form{opacity:0;transform:translateY(20px);transition:opacity var(--transition-fast),transform var(--transition-fast);}
 .show{opacity:1;transform:none;}
@@ -380,6 +382,7 @@ select {appearance:none;background:url('data:image/svg+xml,<svg xmlns="http://ww
   --color-bg:#000;
   --color-text:#ff0;
   --color-accent:#f0f;
+  --color-card-bg:#000;
 }
 
 .invalid {border-color:#e74c3c;}

--- a/styles.scss
+++ b/styles.scss
@@ -1,0 +1,32 @@
+$font-family: 'Poppins', 'DejaVu Sans', system-ui, sans-serif;
+$color-bg: #ffffff;
+$color-text: #222222;
+$color-primary: #0d6efd;
+$color-dark-bg: #121212;
+$color-dark-text: #f1f1f1;
+$transition-fast: 0.3s ease;
+$transition-slow: 0.6s ease;
+
+* {
+  margin:0;
+  padding:0;
+  box-sizing:border-box;
+}
+html { line-height:1.15; -webkit-text-size-adjust:100%; }
+
+body {
+  font-family:$font-family;
+  background:$color-bg;
+  color:$color-text;
+}
+
+.nav {
+  position:sticky;
+  top:0;
+  display:flex;
+  justify-content:space-between;
+}
+
+.has-mega:hover .mega-menu {
+  display:grid;
+}

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'site-cache-v1';
+const CACHE_NAME = 'site-cache-v2';
 const OFFLINE_URL = 'offline.html';
 
 const CORE_ASSETS = [
@@ -29,13 +29,87 @@ self.addEventListener('activate', event => {
 });
 
 self.addEventListener('fetch', event => {
+  if (event.request.method !== 'GET') return;
   if (event.request.mode === 'navigate') {
     event.respondWith(
-      fetch(event.request).catch(() => caches.match(OFFLINE_URL))
+      fetch(event.request).then(res => {
+        const copy = res.clone();
+        caches.open(CACHE_NAME).then(c => c.put(event.request, copy));
+        return res;
+      }).catch(() => caches.match(event.request).then(r => r || caches.match(OFFLINE_URL)))
     );
     return;
   }
+
+  if (event.request.destination === 'image') {
+    event.respondWith(
+      caches.open('images').then(async cache => {
+        const cached = await cache.match(event.request);
+        const fetched = fetch(event.request).then(resp => {
+          cache.put(event.request, resp.clone());
+          return resp;
+        });
+        return cached || fetched;
+      })
+    );
+    return;
+  }
+
   event.respondWith(
-    caches.match(event.request).then(res => res || fetch(event.request))
+    caches.match(event.request).then(cached => {
+      const fetchPromise = fetch(event.request).then(resp => {
+        caches.open(CACHE_NAME).then(c => c.put(event.request, resp.clone()));
+        return resp;
+      });
+      return cached || fetchPromise;
+    })
   );
 });
+
+self.addEventListener('push', event => {
+  const data = event.data ? event.data.json() : {};
+  const title = data.title || 'Notification';
+  const options = { body: data.body || '', icon: 'https://placehold.co/96x96' };
+  event.waitUntil(self.registration.showNotification(title, options));
+});
+
+self.addEventListener('sync', event => {
+  if(event.tag === 'sync-forms') {
+    event.waitUntil(handleFormSync());
+  }
+  if(event.tag === 'sync-analytics') {
+    event.waitUntil(handleAnalyticsSync());
+  }
+});
+
+// IndexedDB helpers in SW
+function openDB(name, store){
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(name,1);
+    req.onupgradeneeded = () => req.result.createObjectStore(store, {autoIncrement:true});
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
+const formDB = openDB('form-store','forms');
+const analyticsDB = openDB('analytics-store','events');
+
+async function handleFormSync(){
+  const db = await formDB;
+  const tx = db.transaction('forms','readwrite');
+  const store = tx.objectStore('forms');
+  const all = await store.getAll();
+  await Promise.all(all.map(entry => fetch(entry.url,{method:'POST',body:new URLSearchParams(entry.data)})));
+  store.clear();
+  await new Promise(r=>tx.oncomplete=r);
+}
+
+async function handleAnalyticsSync(){
+  const db = await analyticsDB;
+  const tx = db.transaction('events','readwrite');
+  const store = tx.objectStore('events');
+  const all = await store.getAll();
+  await Promise.all(all.map(ev => fetch('/analytics',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(ev)})));
+  store.clear();
+  await new Promise(r=>tx.oncomplete=r);
+}


### PR DESCRIPTION
## Summary
- loosen CSP to permit YouTube embeds
- load YouTube iframe API
- replace hero `<video>` element with flexible container
- add mute/unmute control and style it
- initialize hero video in JS and support YouTube or MP4 sources
- document hero video customization in README

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6840e39e8668832e9f7d5ed8912a15ae