### PR TITLE
Fix meta tag in Services page

### DIFF
--- a/services.html
+++ b/services.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover, interactive-widget=resizes-content">
   <meta http-equiv="Cross-Origin-Opener-Policy" content="same-origin">
   <meta http-equiv="Cross-Origin-Embedder-Policy" content="credentialless">
-  <meta name="description" content="Discover our HVAC design-build and industrial retrofit services in Chicago."
+  <meta name="description" content="Discover our HVAC design-build and industrial retrofit services in Chicago.">
   <title>Services | Allied Mechanical</title>
   <link rel="canonical" href="https://www.allied-mechanical.com/services.html">
   <link rel="prefetch" href="/" as="document">


### PR DESCRIPTION
## Summary
- close the meta description tag in `services.html`

## Testing
- `tidy -errors -q index.html about.html services.html 404.html`
- `node -c assets/js/main.js assets/js/analytics.js`


------
https://chatgpt.com/codex/tasks/task_e_6841126a0c60832ebcabd43d6e8e7c0d