### PR TITLE
Redesign static site landing page

### DIFF
--- a/about.html
+++ b/about.html
@@ -28,22 +28,26 @@
 <div id="progressBar" hidden aria-hidden="true" role="progressbar" aria-label="Scroll progress"></div>
 <a href="#main" class="skip">Skip to content</a>
 <header data-menu="closed">
-  <button type="button" id="navToggle" aria-expanded="false" aria-controls="navList">☰</button>
-  <nav inert aria-hidden="true">
-    <ul id="navList">
-      <li><a href="/">Home</a></li>
-      <li><a href="/services.html">Services</a></li>
-      <li><a href="/about.html" aria-current="page">About</a></li>
-    </ul>
-  </nav>
-  <div>
-    <button type="button" id="themeToggle" class="cta">Toggle dark mode</button>
-    <button type="button" id="fontToggle" class="cta" aria-pressed="false">A+</button>
+  <div class="container">
+    <button type="button" id="navToggle" aria-expanded="false" aria-controls="navList">☰</button>
+    <nav inert aria-hidden="true">
+      <ul id="navList">
+        <li><a href="/">Home</a></li>
+        <li><a href="/services.html">Services</a></li>
+        <li><a href="/about.html" aria-current="page">About</a></li>
+      </ul>
+    </nav>
+    <div>
+      <button type="button" id="themeToggle" class="cta">Toggle dark mode</button>
+      <button type="button" id="fontToggle" class="cta" aria-pressed="false">A+</button>
+    </div>
   </div>
 </header>
-<main id="main" tabindex="-1">
-  <h1>About Allied Mechanical</h1>
-  <p>Allied Mechanical specializes in commercial HVAC installations and service across Chicago.</p>
+<main id="main" tabindex="-1" class="section">
+  <div class="container">
+    <h1>About Allied Mechanical</h1>
+    <p>Allied Mechanical specializes in commercial HVAC installations and service across Chicago.</p>
+  </div>
 </main>
 <footer>
   <p>&copy; <span id="year"></span> Allied Mechanical</p>

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -5,7 +5,7 @@
   font-display: swap;
 }
 
-@layer reset, base, components;
+@layer reset, base, layout, components;
 @layer reset {
   *, *::before, *::after { box-sizing: border-box; margin:0; padding:0; }
 }
@@ -14,6 +14,7 @@
     --pad: env(safe-area-inset);
     --accent: #007BFF;
     --font-scale: 1;
+    --max-width: 80rem;
   }
   body {
     font-family: 'Inter', system-ui, sans-serif;
@@ -23,38 +24,55 @@
     font-size:calc(1rem * var(--font-scale));
     scroll-behavior:smooth;
   }
+  .container { max-width:var(--max-width); margin:0 auto; padding:0 1rem; }
   a { color:#036; }
   :focus-visible { outline:2px solid currentColor; }
   .skip { position:absolute; left:-999px; top:auto; width:1px; height:1px; overflow:hidden; }
   .skip:focus { position:static; width:auto; height:auto; }
   header {
     container-type:inline-size;
-    position:relative;
+    position:sticky;
+    top:0;
+    z-index:100;
+    background:#fff;
+    box-shadow:0 2px 4px rgba(0,0,0,.1);
+  }
+  header > .container {
     display:flex;
     align-items:center;
     justify-content:space-between;
+    padding:.5rem 0;
   }
-  nav { position:fixed; top:0; left:0; right:0; background:rgba(255,255,255,.8); backdrop-filter:blur(5px); }
-  nav ul { list-style:none; margin:0; padding:1rem; display:flex; gap:1rem; }
+  nav ul { list-style:none; margin:0; padding:0; display:flex; gap:1rem; }
   nav a { text-decoration:none; color:#014; }
   nav a[aria-current="page"] { font-weight:bold; text-decoration:underline; }
   #progressBar { position:fixed; inset:0 0 auto 0; height:4px; width:0; background:var(--accent); z-index:10; }
   /* Back to top button sits above the call FAB */
   #topBtn { right:1rem; bottom:5rem; }
-  /* Use modern viewport units with fallback for older browsers */
+  /* Hero section */
   .hero {
     height:100dvh;
     height:calc(var(--vh,1vh) * 100);
-    display:grid;
-    place-items:center;
+    display:flex;
+    align-items:center;
+    justify-content:center;
     text-align:center;
-    position:relative;
+    background:linear-gradient(135deg,var(--accent),#00b3ff);
+    color:#fff;
   }
   @container size inline(700px) { .hero { height:70dvh; } }
-  canvas { width:100%; height:100%; position:absolute; inset:0; }
   .cta { position:relative; padding:1rem 2rem; font-size:1.2rem; background:var(--accent); color:#fff; border:none; border-radius:.25rem; cursor:pointer; }
   .fab { position:fixed; right:1rem; bottom:1rem; background:var(--accent); color:#fff; border-radius:50%; width:56px; height:56px; display:flex; align-items:center; justify-content:center; font-size:1.5rem; cursor:pointer; }
 }
+
+@layer layout {
+  .section { padding:4rem 0; }
+  .features-grid { display:grid; gap:2rem; grid-template-columns:repeat(auto-fit,minmax(15rem,1fr)); }
+  .feature-card { background:#fff; padding:2rem; border-radius:.5rem; box-shadow:0 2px 5px rgba(0,0,0,.1); }
+  .section h2 { margin-bottom:1rem; text-align:center; }
+  .section p { margin-bottom:1rem; }
+}
+
 @layer components {
   .fab { box-shadow:0 2px 5px rgba(0,0,0,.2); }
   #topBtn { display:none; }
@@ -71,7 +89,6 @@
   }
 }
 
-@media (prefers-reduced-motion: reduce) { canvas { display:none; } }
 @media (forced-colors: active) { body { forced-color-adjust:none; } }
 @media (prefers-contrast: more) {
   body { background:#fff; color:#000; }

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -22,8 +22,6 @@ if (quoteBtn) {
   });
 }
 
-const reduceData = navigator.connection?.saveData || matchMedia("(prefers-reduced-data: reduce)").matches;
-if (reduceData) { document.getElementById("gpuCanvas")?.remove(); }
 // handle PWA install prompt
 let deferredPrompt;
 const installBanner = document.getElementById('installBanner');

--- a/index.html
+++ b/index.html
@@ -25,25 +25,6 @@
   <link rel="preload" href="/fonts/Inter.var.woff2" as="font" type="font/woff2" crossorigin integrity="sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=">
   <style nonce="amNonce">
     body { margin:0; padding: env(safe-area-inset); }
-    /* Use dynamic viewport units with a fallback */
-    .hero {
-      height:100dvh;
-      height:calc(var(--vh, 1vh) * 100);
-      display:grid;
-      place-items:center;
-      text-align:center;
-      position:relative;
-    }
-    @container size inline(700px) {
-      .hero { height:70dvh; }
-    }
-    canvas { width:100%; height:100%; position:absolute; inset:0; }
-    @media (prefers-reduced-motion: reduce) {
-      canvas { display:none; }
-    }
-    @media (forced-colors: active) {
-      body { forced-color-adjust:none; }
-    }
   </style>
   <script type="importmap" nonce="amNonce">
     {
@@ -78,32 +59,73 @@
 <div id="progressBar" hidden aria-hidden="true" role="progressbar" aria-label="Scroll progress"></div>
 <a href="#main" class="skip">Skip to content</a>
 <header aria-label="Site header" data-menu="closed">
-  <button type="button" id="navToggle" aria-expanded="false" aria-controls="navList">☰</button>
-  <nav inert aria-hidden="true">
-    <ul id="navList">
-      <li><a href="/" aria-current="page">Home</a></li>
-      <li><a href="/services.html">Services</a></li>
-      <li><a href="/about.html">About</a></li>
-    </ul>
-  </nav>
-  <div>
-    <button type="button" id="themeToggle" class="cta">Toggle dark mode</button>
-    <button type="button" id="fontToggle" class="cta" aria-pressed="false">A+</button>
+  <div class="container">
+    <button type="button" id="navToggle" aria-expanded="false" aria-controls="navList">☰</button>
+    <nav inert aria-hidden="true">
+      <ul id="navList">
+        <li><a href="/" aria-current="page">Home</a></li>
+        <li><a href="/services.html">Services</a></li>
+        <li><a href="/about.html">About</a></li>
+      </ul>
+    </nav>
+    <div>
+      <button type="button" id="themeToggle" class="cta">Toggle dark mode</button>
+      <button type="button" id="fontToggle" class="cta" aria-pressed="false">A+</button>
+    </div>
   </div>
 </header>
 <main id="main" tabindex="-1">
-  <section class="hero" aria-label="Hero">
-    <canvas id="gpuCanvas" aria-hidden="true"></canvas>
-    <!-- Placeholder image. Replace data URI with /assets/img/hero.avif -->
-    <img src="/assets/img/hero-1600.avif"
-         alt="HVAC systems" width="1600" height="900"
-         srcset="/assets/img/hero-400.avif 400w,
-                 /assets/img/hero-800.avif 800w,
-                 /assets/img/hero-1600.avif 1600w"
-         sizes="(max-width:600px) 100vw, 50vw" fetchpriority="high" loading="lazy" decoding="async">
+<section class="hero section" aria-label="Hero">
+  <div class="container">
+    <h1>Allied Mechanical</h1>
+    <p>Commercial HVAC Excellence in Chicago</p>
     <button class="cta" id="quoteBtn">Get a Quote</button>
     <div id="installBanner" hidden aria-live="polite">
       <button id="installBtn" class="cta">Install App</button>
+    </div>
+  </div>
+</section>
+  <section class="features section" aria-label="Key features">
+    <div class="container">
+      <h2>Why Choose Allied Mechanical</h2>
+      <div class="features-grid">
+        <div class="feature-card">
+          <h3>Expert Team</h3>
+          <p>Certified technicians dedicated to quality workmanship.</p>
+        </div>
+        <div class="feature-card">
+          <h3>24/7 Service</h3>
+          <p>Rapid response around the clock for urgent needs.</p>
+        </div>
+        <div class="feature-card">
+          <h3>Energy Efficiency</h3>
+          <p>Modern solutions that reduce operating costs.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="services section" aria-label="Services summary">
+    <div class="container">
+      <h2>Our Services</h2>
+      <p>Design-build contracting and industrial retrofit services.</p>
+      <a href="/services.html" class="cta">Learn More</a>
+    </div>
+  </section>
+
+  <section class="about section" aria-label="About">
+    <div class="container">
+      <h2>About Allied Mechanical</h2>
+      <p>Serving Chicago businesses with reliable HVAC expertise for over 20 years.</p>
+      <a href="/about.html" class="cta">Read More</a>
+    </div>
+  </section>
+
+  <section class="contact section" aria-label="Contact">
+    <div class="container">
+      <h2>Ready to Start?</h2>
+      <p>Call <a href="tel:+13125550110">312-555-0110</a> or request a quote today.</p>
+      <a href="/services.html#quote" class="cta">Request Quote</a>
     </div>
   </section>
 </main>

--- a/services.html
+++ b/services.html
@@ -28,27 +28,31 @@
 <div id="progressBar" hidden aria-hidden="true" role="progressbar" aria-label="Scroll progress"></div>
 <a href="#main" class="skip">Skip to content</a>
 <header data-menu="closed">
-  <button type="button" id="navToggle" aria-expanded="false" aria-controls="navList">☰</button>
-  <nav inert aria-hidden="true">
-    <ul id="navList">
-      <li><a href="/">Home</a></li>
-      <li><a href="/services.html" aria-current="page">Services</a></li>
-      <li><a href="/about.html">About</a></li>
-    </ul>
-  </nav>
-  <div>
-    <button type="button" id="themeToggle" class="cta">Toggle dark mode</button>
-    <button type="button" id="fontToggle" class="cta" aria-pressed="false">A+</button>
+  <div class="container">
+    <button type="button" id="navToggle" aria-expanded="false" aria-controls="navList">☰</button>
+    <nav inert aria-hidden="true">
+      <ul id="navList">
+        <li><a href="/">Home</a></li>
+        <li><a href="/services.html" aria-current="page">Services</a></li>
+        <li><a href="/about.html">About</a></li>
+      </ul>
+    </nav>
+    <div>
+      <button type="button" id="themeToggle" class="cta">Toggle dark mode</button>
+      <button type="button" id="fontToggle" class="cta" aria-pressed="false">A+</button>
+    </div>
   </div>
 </header>
-<main id="main" tabindex="-1">
-  <h1>Our Services</h1>
-  <h2>Design-Build Contracting</h2>
-  <p>From concept to completion, we handle every aspect of your HVAC design-build project.</p>
-  <h2>Industrial Retrofit Services</h2>
-  <p>Upgrade your existing systems with minimal downtime and maximum efficiency.</p>
-  <h2 id="quote">Request a Quote</h2>
-  <p>Contact us for pricing tailored to your project.</p>
+<main id="main" tabindex="-1" class="section">
+  <div class="container">
+    <h1>Our Services</h1>
+    <h2>Design-Build Contracting</h2>
+    <p>From concept to completion, we handle every aspect of your HVAC design-build project.</p>
+    <h2>Industrial Retrofit Services</h2>
+    <p>Upgrade your existing systems with minimal downtime and maximum efficiency.</p>
+    <h2 id="quote">Request a Quote</h2>
+    <p>Contact us for pricing tailored to your project.</p>
+  </div>
 </main>
 <footer>
   <p>&copy; <span id="year"></span> Allied Mechanical</p>


### PR DESCRIPTION
## Summary
- clean up inline styles and add responsive layout classes
- redesign hero section with gradient background
- add features, services, about and contact sections
- wrap page sections in a container for consistent width
- update JS and stylesheets for new layout

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6841b69a0e7c832eab038d77a861f601