### PR TITLE
Fix paint worklet module reference

### DIFF
--- a/paint-worklet.js
+++ b/paint-worklet.js
@@ -4,5 +4,5 @@
  * Purpose: Register CSS Paint Worklet for procedural steel I-beam drawing.
  */
 if ('CSS' in window && CSS.paintWorklet) {
-  CSS.paintWorklet.addModule('paint-worklet.js');
+  CSS.paintWorklet.addModule('paint-worklet1.js');
 }


### PR DESCRIPTION
## Summary
- point `paint-worklet.js` to load `paint-worklet1.js`
- confirm paint-worklet1.js still houses `registerPaint`

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6841d075a740832e85e11f0a160eb558