### PR TITLE
Remove console output from production

### DIFF
--- a/script.js
+++ b/script.js
@@ -12,6 +12,11 @@ import { handleForm } from "./contactform.js";                 // Contact form v
 import { drawMap } from "./mapcanvas.js";                       // Live canvas map rendering
 import { initAnalytics } from "./analytics.js";            // Analytics beacon stub
 
+// Toggle console output during development
+const DEBUG_MODE = false;
+const debugLog = (...args) => { if (DEBUG_MODE) console.log(...args); };
+const debugWarn = (...args) => { if (DEBUG_MODE) console.warn(...args); };
+
 /* ========================= HEADER / NAV BEHAVIOR ========================= */
 const header = document.getElementById("header");
 let lastScrollY = window.scrollY;
@@ -228,8 +233,8 @@ fab.addEventListener("click", () => {
 if ('serviceWorker' in navigator) {
   window.addEventListener('load', () => {
     navigator.serviceWorker.register('/sw.js')
-      .then(reg => console.log('Service Worker registered:', reg))
-      .catch(err => console.warn('Service Worker registration failed:', err));
+      .then(reg => debugLog('Service Worker registered:', reg))
+      .catch(err => debugWarn('Service Worker registration failed:', err));
   });
 }
 


### PR DESCRIPTION
## Summary
- hide console logging behind a `DEBUG_MODE` flag
- use the new `debugLog` and `debugWarn` helpers for service worker registration

## Testing
- `node -c script.js`

------
https://chatgpt.com/codex/tasks/task_e_6841d33c5f74832e89f02b82c626f2d7