### PR TITLE
Implement requestIdleCallback fallback

### DIFF
--- a/script.js
+++ b/script.js
@@ -234,4 +234,8 @@ if ('serviceWorker' in navigator) {
 }
 
 /* ========================= ANALYTICS ========================= */
-requestIdleCallback(initAnalytics);
+const analyticsIdleHandle = (window.requestIdleCallback || function(cb){
+  return setTimeout(cb, 200);
+})(initAnalytics);
+// If cancellation is needed elsewhere, use
+//   (window.cancelIdleCallback || clearTimeout)(analyticsIdleHandle);


### PR DESCRIPTION
## Summary
- fallback to `setTimeout` when `requestIdleCallback` isn't available
- note how to cancel the idle callback when using the fallback

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_6841d3385004832ebb7c51b11f3c931c