### PR TITLE
Enhance mobile navigation

### DIFF
--- a/script.js
+++ b/script.js
@@ -58,6 +58,42 @@ mobileMenu.querySelectorAll("a").forEach(link => {
   });
 });
 
+const setMenuHeight = () => {
+  mobileMenu.style.height = `${window.innerHeight}px`;
+};
+window.addEventListener("resize", setMenuHeight);
+window.addEventListener("orientationchange", setMenuHeight);
+setMenuHeight();
+
+let swipeStartX = null;
+mobileMenu.addEventListener("pointerdown", (e) => {
+  swipeStartX = e.clientX;
+});
+mobileMenu.addEventListener("pointerup", (e) => {
+  if (swipeStartX !== null && Math.abs(e.clientX - swipeStartX) > 50) {
+    mobileMenu.classList.remove("open");
+    document.body.style.overflow = "";
+  }
+  swipeStartX = null;
+});
+
+const sections = document.querySelectorAll("main > section[id]");
+const mobileLinks = mobileMenu.querySelectorAll("a");
+const sectionObserver = new IntersectionObserver((entries) => {
+  entries.forEach(entry => {
+    if (entry.isIntersecting) {
+      mobileLinks.forEach(link => {
+        if (link.getAttribute("href") === `#${entry.target.id}`) {
+          link.classList.add("active");
+        } else {
+          link.classList.remove("active");
+        }
+      });
+    }
+  });
+}, { threshold: 0.6 });
+sections.forEach(sec => sectionObserver.observe(sec));
+
 /* ========================= HERO ANIMATIONS ========================= */
 const heroTitle = document.querySelector(".hero-title");
 const heroCtaPrimary = document.getElementById("hero-cta-primary");

--- a/style.css
+++ b/style.css
@@ -127,12 +127,21 @@ button {
 /* ===================================== */
 /* HEADER / NAV */
 /* ===================================== */
+#header {
+  position: absolute;
+  top: 0;
+  width: 100%;
+  z-index: 40;
+  transition: box-shadow var(--dur-fast);
+}
 #header.hidden {
   transform: translateY(-100%);
 }
 #header.scrolled {
+  position: fixed;
   background: rgba(26, 43, 76, 0.8);
   backdrop-filter: blur(8px);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.15);
 }
 .header-inner {
   display: flex;
@@ -151,6 +160,7 @@ button {
   font-size: var(--fs-100);
   position: relative;
   padding: var(--space-1) 0;
+  outline-offset: 2px;
 }
 .nav-links a::after {
   content: "";
@@ -166,6 +176,10 @@ button {
 .nav-links a:focus::after {
   width: 100%;
 }
+.nav-links a:focus-visible,
+.mobile-menu a:focus-visible {
+  outline: 2px solid var(--clr-accent-600);
+}
 .hamburger {
   display: none;
 }
@@ -177,6 +191,37 @@ button {
 }
 .mobile-menu.open {
   display: flex;
+}
+
+@media (max-width: 640px) {
+  .header-inner {
+    padding: var(--space-2) var(--space-3);
+  }
+  .hamburger {
+    display: block;
+    padding: var(--space-2);
+  }
+  .nav-links {
+    display: none;
+  }
+  .mobile-menu {
+    position: fixed;
+    inset: 0;
+    height: 100vh;
+    background: rgba(26, 43, 76, 0.95);
+    transform: translateX(100%);
+    transition: transform var(--dur-medium) var(--ease-emphasis);
+  }
+  .mobile-menu.open {
+    transform: translateX(0);
+  }
+  .mobile-menu a {
+    padding: var(--space-3) var(--space-5);
+    font-size: var(--fs-300);
+  }
+  .mobile-menu a.active {
+    text-decoration: underline;
+  }
 }
 
 /* ===================================== */


### PR DESCRIPTION
## Summary
- keep header fixed after scrolling and add drop shadow
- provide focus styles for nav links
- create animated slide-in mobile menu
- add swipe to dismiss menu and highlight active section

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_6841d1bfbc80832ea309d002cdd02e21