### PR TITLE
Enhance service worker caching

### DIFF
--- a/icons/icon-192.svg
+++ b/icons/icon-192.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="192" height="192" viewBox="0 0 192 192">
+  <rect width="192" height="192" rx="24" ry="24" fill="#1a2b4c"/>
+  <text x="96" y="120" text-anchor="middle" font-size="72" fill="#fff">A</text>
+</svg>

--- a/icons/icon-512.svg
+++ b/icons/icon-512.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512">
+  <rect width="512" height="512" rx="64" ry="64" fill="#1a2b4c"/>
+  <text x="256" y="320" text-anchor="middle" font-size="200" fill="#fff">A</text>
+</svg>

--- a/manifest.json
+++ b/manifest.json
@@ -7,12 +7,12 @@
   "theme_color": "#1a2b4c",
   "icons": [
     {
-      "src": "data:image/svg+xml;base64,…",
+      "src": "icons/icon-192.svg",
       "sizes": "192x192",
       "type": "image/svg+xml"
     },
     {
-      "src": "data:image/svg+xml;base64,…",
+      "src": "icons/icon-512.svg",
       "sizes": "512x512",
       "type": "image/svg+xml"
     }

--- a/sw.js
+++ b/sw.js
@@ -11,12 +11,14 @@ const CACHE_ASSETS = [
   '/index.html',
   '/style.css?v=202506051200',
   '/script.js?v=202506051200',
-  '/data:image/svg+xml;base64,…',
   '/manifest.json',
-  '/offline.html'
+  '/offline.html',
+  '/icons/icon-192.svg',
+  '/icons/icon-512.svg'
 ];
 
 self.addEventListener('install', (e) => {
+  self.skipWaiting();
   e.waitUntil(
     caches.open(CACHE_VERSION).then((cache) => cache.addAll(CACHE_ASSETS))
   );
@@ -38,18 +40,34 @@ self.addEventListener('activate', (e) => {
 
 self.addEventListener('fetch', (e) => {
   if (e.request.method !== 'GET') return;
-  if (new URL(e.request.url).origin !== location.origin) return;
+  const url = new URL(e.request.url);
+  if (url.origin !== location.origin) return;
+
+  if (e.request.mode === 'navigate') {
+    e.respondWith(
+      fetch(e.request)
+        .then((res) => {
+          if (res && res.status === 200) {
+            const clone = res.clone();
+            caches.open(CACHE_VERSION).then((cache) => cache.put(e.request, clone));
+          }
+          return res;
+        })
+        .catch(() => caches.match(e.request).then((cached) => cached || caches.match('/offline.html')))
+    );
+    return;
+  }
+
   e.respondWith(
     caches.match(e.request).then((cached) => {
       if (cached) return cached;
       return fetch(e.request).then((res) => {
-        if (!res || res.status !== 200 || res.type !== 'basic') return res;
-        const clone = res.clone();
-        caches.open(CACHE_VERSION).then((cache) => cache.put(e.request, clone));
+        if (res && res.status === 200 && res.type === 'basic') {
+          const clone = res.clone();
+          caches.open(CACHE_VERSION).then((cache) => cache.put(e.request, clone));
+        }
         return res;
       });
-    }).catch(() => {
-      return caches.match('/offline.html');
-    })
+    }).catch(() => caches.match('/offline.html'))
   );
 });


### PR DESCRIPTION
## Summary
- add real icon files
- update manifest.json to reference new icons
- improve service worker caching
  - cache new icons
  - activate new versions immediately using `skipWaiting`
  - provide navigation network-first logic with offline fallback

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6841da3e1eac832ea7dd4718bd77f016