### PR TITLE
Add skip hero animation control

### DIFF
--- a/index.html
+++ b/index.html
@@ -1069,6 +1069,7 @@
   <!-- ========================= HERO ============================ -->
   <main id="main-content">
     <section id="hero" class="hero-section" role="region" aria-labelledby="hero-title">
+      <button id="skip-hero" class="skip-hero">Skip animation</button>
       <div class="hero-background"></div>
       <canvas id="blueprint-canvas" aria-label="Rotating blueprint placeholder"></canvas>
       <div class="hero-content">

--- a/script.js
+++ b/script.js
@@ -96,6 +96,7 @@ sections.forEach(sec => sectionObserver.observe(sec));
 
 /* ========================= HERO ANIMATIONS ========================= */
 const heroTitle = document.querySelector(".hero-title");
+const skipHero = document.getElementById("skip-hero");
 const heroCtaPrimary = document.getElementById("hero-cta-primary");
 const rotatingObserver = new IntersectionObserver((entries) => {
   entries.forEach(entry => {
@@ -105,6 +106,10 @@ const rotatingObserver = new IntersectionObserver((entries) => {
   });
 }, { threshold: 0.5 });
 rotatingObserver.observe(heroTitle);
+
+skipHero?.addEventListener('click', () => {
+  heroTitle.classList.add('visible');
+});
 
 // Magnetic cursor effect on Primary CTA
 document.addEventListener("mousemove", (e) => {

--- a/style.css
+++ b/style.css
@@ -232,6 +232,22 @@ button {
   height: 100dvh;
   overflow: hidden;
 }
+.skip-hero {
+  position: absolute;
+  left: -999px;
+  top: var(--space-2);
+  background: var(--clr-surface-50);
+  color: var(--clr-primary-900);
+  padding: var(--space-1) var(--space-2);
+  border-radius: var(--radius-sm);
+  font-size: var(--fs-50);
+  text-decoration: none;
+  z-index: 2;
+}
+.skip-hero:focus {
+  left: 50%;
+  transform: translateX(-50%);
+}
 .hero-background {
   position: absolute;
   inset: 0;
@@ -263,13 +279,11 @@ button {
 .hero-title .line-2 {
   display: block;
   opacity: 0;
-  transform: translateY(50px);
-  transition: opacity 600ms var(--ease-emphasis), transform 600ms var(--ease-emphasis);
+  transition: opacity 600ms var(--ease-emphasis);
 }
 .hero-title.visible .line-1,
 .hero-title.visible .line-2 {
   opacity: 1;
-  transform: translateY(0);
 }
 .hero-subtitle #rotating-phrase {
   display: inline-block;


### PR DESCRIPTION
## Summary
- allow skipping hero animation with a hidden button
- simplify hero title animation to fade-in only

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6841e029f910832e8cbea527492ef40a