### PR TITLE
Add dark mode toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -297,6 +297,11 @@
           <path d="M3 12h18M3 6h18M3 18h18" stroke="#333" stroke-width="2" stroke-linecap="round"/>
         </svg>
       </button>
+      <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark mode">
+        <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true">
+          <path d="M12 2a9.93 9.93 0 015 1.33A7 7 0 1110.67 19 10 10 0 0112 2z"/>
+        </svg>
+      </button>
     </div>
   </header>
 

--- a/scripts.js
+++ b/scripts.js
@@ -401,4 +401,14 @@ document.addEventListener('DOMContentLoaded', () => {
   initScrollAnimations();
   initLazyLoad();
   initCarousel();
+  const themeToggleBtn = document.getElementById('theme-toggle');
+  const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+  const savedTheme = localStorage.getItem('theme') || (prefersDark ? 'dark' : 'light');
+  document.documentElement.setAttribute('data-theme', savedTheme);
+  themeToggleBtn.addEventListener('click', () => {
+    const current = document.documentElement.getAttribute('data-theme');
+    const next = current === 'dark' ? 'light' : 'dark';
+    document.documentElement.setAttribute('data-theme', next);
+    localStorage.setItem('theme', next);
+  });
 });

--- a/styles.css
+++ b/styles.css
@@ -959,3 +959,32 @@ button {
     transition: none;
   }
 }
+
+/* --------------------------------------------
+   DARK THEME SUPPORT
+-------------------------------------------- */
+[data-theme='dark'] {
+  --color-bg: #1e2a38;
+  --color-text: #ffffff;
+  --color-primary: #2a9d8f;
+  --color-secondary: #f4a261;
+  --color-muted: #cccccc;
+  --color-border: #555555;
+}
+
+.theme-toggle {
+  margin-left: 1rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background: var(--color-primary);
+  color: #fff;
+  transition: background var(--transition-fast);
+}
+.theme-toggle:hover,
+.theme-toggle:focus {
+  background: var(--color-tertiary);
+}


### PR DESCRIPTION
## Summary
- add button in header to toggle dark theme
- support dark mode colors in stylesheet
- store theme preference and apply via script

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68434b7763b8832e9f79ef45476406f5