### PR TITLE
Add privacy friendly analytics mention

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,6 @@ This project is a fully static, responsive landing page ready for GitHub Pages d
 
 ## Deployment
 Enable **GitHub Pages** from the repository settings, choosing the main branch. The included workflow `deploy.yml` can automate publishing when changes are pushed to `main`.
+
+## Privacy-Friendly Analytics
+This template ships without analytics, but you can integrate a privacy-focused service such as [Plausible](https://plausible.io/). Load their script only after users opt in to tracking.

--- a/index.html
+++ b/index.html
@@ -16,6 +16,15 @@
   <link rel="preload" href="/assets/css/main.css" as="style">
   <link rel="stylesheet" href="/assets/css/main.css">
   <script defer src="/assets/js/main.js"></script>
+  <script>
+    if (localStorage.getItem('analyticsConsent') === 'true') {
+      const s = document.createElement('script');
+      s.defer = true;
+      s.dataset.domain = 'example.com';
+      s.src = 'https://plausible.io/js/script.js';
+      document.head.appendChild(s);
+    }
+  </script>
 </head>
 <body class="min-h-screen antialiased bg-white text-gray-900" data-theme="light">
   <header class="bg-gradient-to-r from-primary to-accent text-white">


### PR DESCRIPTION
## Summary
- document Plausible analytics option
- load Plausible script only if the user has given consent

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68438cba7fac832e825a59ced385c5c7