### PR TITLE
Enhance form accessibility and validation

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -44,4 +44,48 @@
       document.body.setAttribute('data-theme', theme);
     });
   }
+
+  const form = document.querySelector('#contact form');
+  if (form) {
+    const emailInput = form.querySelector('#email');
+    const messageInput = form.querySelector('#message');
+    const emailError = document.getElementById('email-error');
+    const messageError = document.getElementById('message-error');
+
+    const validators = {
+      email: value => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value),
+      message: value => value.trim().length > 0
+    };
+
+    const showError = (input, el, msg) => {
+      if (el) el.textContent = msg;
+      input.setAttribute('aria-invalid', 'true');
+    };
+
+    const clearError = (input, el) => {
+      if (el) el.textContent = '';
+      input.removeAttribute('aria-invalid');
+    };
+
+    form.addEventListener('submit', e => {
+      let valid = true;
+      if (!validators.email(emailInput.value)) {
+        showError(emailInput, emailError, 'Please enter a valid email.');
+        valid = false;
+      }
+      if (!validators.message(messageInput.value)) {
+        showError(messageInput, messageError, 'Message is required.');
+        valid = false;
+      }
+      if (!valid) e.preventDefault();
+    });
+
+    [emailInput, messageInput].forEach(input => {
+      const errEl = input.id === 'email' ? emailError : messageError;
+      input.addEventListener('input', () => {
+        const isValid = validators[input.id](input.value);
+        if (isValid) clearError(input, errEl);
+      });
+    });
+  }
 })();

--- a/index.html
+++ b/index.html
@@ -70,8 +70,9 @@
         <div class="inline-flex mb-8 items-center gap-2">
           <span>Monthly</span>
           <label class="relative inline-flex items-center cursor-pointer">
-            <input type="checkbox" value="" id="billing-toggle" class="sr-only peer">
+            <input type="checkbox" value="" id="billing-toggle" class="sr-only peer" aria-required="false" aria-describedby="billing-desc">
             <div class="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-blue-300 rounded-full peer dark:bg-gray-700 peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-0.5 after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all dark:border-gray-600 peer-checked:bg-primary"></div>
+              <span id="billing-desc" class="sr-only">Toggle yearly billing</span>
           </label>
           <span>Yearly</span>
         </div>
@@ -138,9 +139,13 @@
 
     <section class="py-20" id="contact">
       <div class="container mx-auto grid md:grid-cols-2 gap-8">
-        <form action="https://formspree.io/f/yourformid" method="POST" class="space-y-4">
-          <div class="float-label"><input id="email" type="email" name="email" required placeholder=" " class="peer w-full p-3 border rounded"><label for="email">Email</label></div>
-          <div class="float-label"><textarea id="message" name="message" required placeholder=" " class="peer w-full p-3 border rounded h-32"></textarea><label for="message">Message</label></div>
+        <form action="https://formspree.io/f/yourformid" method="POST" novalidate class="space-y-4">
+          <div class="float-label"><input id="email" type="email" name="email" required aria-required="true" aria-describedby="email-desc email-error" placeholder=" " class="peer w-full p-3 border rounded"><label for="email">Email</label>
+            <p id="email-desc" class="sr-only">Please enter a valid email address.</p>
+            <p id="email-error" class="text-red-600 text-sm mt-1" aria-live="polite"></p></div>
+          <div class="float-label"><textarea id="message" name="message" required aria-required="true" aria-describedby="message-desc message-error" placeholder=" " class="peer w-full p-3 border rounded h-32"></textarea><label for="message">Message</label>
+            <p id="message-desc" class="sr-only">Tell us how we can help you.</p>
+            <p id="message-error" class="text-red-600 text-sm mt-1" aria-live="polite"></p></div>
           <button type="submit" class="bg-primary text-white py-2 px-4 rounded hover:bg-blue-700 transition">Submit</button>
         </form>
         <iframe src="https://www.openstreetmap.org/export/embed.html?bbox=0,0,0,0" class="w-full h-64 rounded" loading="lazy" title="Map"></iframe>


### PR DESCRIPTION
## Summary
- mark interactive inputs as required or optional with `aria-required`
- provide screen reader hints with `aria-describedby`
- add client-side form validation with inline error messages

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68438cb4ac2c832ea539b47810c45550