### PR TITLE
Add TypeScript build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - run: npm ci
+      - run: npm run build
       - uses: actions/upload-pages-artifact@v2
         with:
           path: .

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/assets/js/main.ts
+++ b/assets/js/main.ts
@@ -15,10 +15,11 @@
 
   const toggle = document.getElementById('billing-toggle');
   if (toggle) {
-    toggle.addEventListener('change', () => {
+    const inputToggle = toggle as HTMLInputElement;
+    inputToggle.addEventListener('change', () => {
       document.querySelectorAll('[data-price]').forEach(el => {
-        const base = parseInt(el.getAttribute('data-price'), 10);
-        el.textContent = toggle.checked ? '$' + base * 10 : '$' + base;
+        const base = parseInt(el.getAttribute('data-price') || '0', 10);
+        el.textContent = inputToggle.checked ? '$' + base * 10 : '$' + base;
       });
     });
   }
@@ -26,8 +27,8 @@
   document.querySelectorAll('[aria-controls]').forEach(btn => {
     btn.addEventListener('click', () => {
       const expanded = btn.getAttribute('aria-expanded') === 'true';
-      btn.setAttribute('aria-expanded', !expanded);
-      const panel = document.getElementById(btn.getAttribute('aria-controls'));
+      btn.setAttribute('aria-expanded', (!expanded).toString());
+      const panel = document.getElementById(btn.getAttribute('aria-controls') || '');
       if (panel) {
         panel.style.maxHeight = expanded ? '0' : panel.scrollHeight + 'px';
       }
@@ -35,7 +36,7 @@
   });
 
   const year = document.getElementById('year');
-  if (year) year.textContent = new Date().getFullYear();
+  if (year) year.textContent = new Date().getFullYear().toString();
 
   const themeBtn = document.getElementById('theme-toggle');
   if (themeBtn) {

--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
 <script>tailwind.config={theme:{extend:{colors:{primary:"#2563eb",accent:"#f59e0b"}}}}</script>
   <link rel="preload" href="/assets/css/main.css" as="style">
   <link rel="stylesheet" href="/assets/css/main.css">
-  <script defer src="/assets/js/main.js"></script>
+  <script defer src="/dist/main.js"></script>
 </head>
 <body class="min-h-screen antialiased bg-white text-gray-900" data-theme="light">
   <header class="bg-gradient-to-r from-primary to-accent text-white">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,30 @@
+{
+  "name": "websitetest",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "websitetest",
+      "version": "1.0.0",
+      "license": "ISC",
+      "devDependencies": {
+        "typescript": "^5.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "websitetest",
+  "version": "1.0.0",
+  "description": "This project is a fully static, responsive landing page ready for GitHub Pages deployment. It implements a minimal design system with Tailwind CSS and vanilla JavaScript.",
+  "main": "sw.js",
+  "scripts": {
+    "build": "tsc"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "typescript": "^5.0.0"
+  }
+}

--- a/sw.js
+++ b/sw.js
@@ -5,7 +5,7 @@ workbox.precaching.precacheAndRoute([
   {url: '/index.html', revision: '1'},
   {url: '/offline.html', revision: '1'},
   {url: '/assets/css/main.css', revision: '1'},
-  {url: '/assets/js/main.js', revision: '1'}
+  {url: '/dist/main.js', revision: '1'}
 ]);
 
 workbox.routing.registerRoute(

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "es6",
+    "module": "es6",
+    "rootDir": "assets/js",
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true
+  },
+  "include": ["assets/js/**/*"]
+}


### PR DESCRIPTION
## Summary
- migrate `assets/js/main.js` to TypeScript
- configure TypeScript compiler and Node build
- update script paths in HTML and service worker
- build main script in CI before deploying

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68438cbfc2f0832e88ab2e3c26e9bee9